### PR TITLE
fix for redirect splitting.

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -395,8 +395,8 @@ int start_http_form(int s, char *ip, int port, unsigned char options, char *misc
         if (strlen(str) - strlen(str2) == 0) {
           strcpy(str3, "/");
         } else {
-          strncpy(str3, str + strlen(str2), strlen(str) - strlen(str2) - 1);
-          str3[strlen(str) - strlen(str2) - 1] = 0;
+          strncpy(str3, str + strlen(str2), strlen(str) - strlen(str2));
+          str3[strlen(str) - strlen(str2)] = 0;
         }
       } else {
         strncpy(str2, webtarget, sizeof(str2) - 1);


### PR DESCRIPTION
Hey,

i think there is a bug in the two lines below. I don"t see why there should be a '-1'. 
Here is some debug output of me running hydra against my redmine installation, using my working credentials, which results in a redirect that should be followed ([MOFOE] added by me). 

Old code:  
[DEBUG] hydra_receive_line: waittime: 32, conwait: 0, socket: 5, pid: 27217
[DEBUG] RECV [pid:27217](0 bytes):
[DEBUG] attempt result: found 0, redirect 1, location: https://redmine.cracksucht.de/my/page
[MOFOE] condition: Home
[MOFOE] str2: redmine.cracksucht.de
[MOFOE] str3: /my/pag
[MOFOE] Page redirected to /my/pag
[VERBOSE] Page redirected to http://redmine.cracksucht.de/my/pag
DEBUG_DISCONNECT
DEBUG_CONNECT_OK
[VERBOSE] SSL negotiated cipher: ECDHE-RSA-AES256-SHA
[DEBUG] SEND [pid:27217](277 bytes):
0000:  4745 5420 2f6d 792f 7061 6720 4854 5450    [ GET /my/pag HTTP ]
0010:  2f31 2e30 0d0a 486f 7374 3a20 7265 646d    [ /1.0..Host: redm ]
0020:  696e 652e 6372 6163 6b73 7563 6874 2e64    [ ine.cracksucht.d ]
0030:  650d 0a55 7365 722d 4167 656e 743a 204d    [ e..User-Agent: M ]
0040:  6f7a 696c 6c61 2f34 2e30 2028 4879 6472    [ ozilla/4.0 (Hydr ]
0050:  6129 0d0a 436f 6f6b 6965 3a20 5f72 6564    [ a)..Cookie: _red ]
0060:  6d69 6e65 5f64 6566 6175 6c74 3d42 4168    [ mine_default
...
[DEBUG] hydra_receive_line: waittime: 32, conwait: 0, socket: 5, pid: 27217
[DEBUG] RECV [pid:27217](708 bytes):
0000:  4854 5450 2f31 2e30 2034 3034 204e 6f74    [ HTTP/1.0 404 Not ]
0010:  2046 6f75 6e64 0d0a 4361 6368 652d 436f    [  Found..Cache-Co ]
0020:  6e74 726f 6c3a 206e 6f2d 6361 6368 650d    [ ntrol: no-cache. ]

You can see that it removes the last character from the redirect location resulting in a HTTP 404.

Here is how it looks after removing the '-1':

[DEBUG] hydra_receive_line: waittime: 32, conwait: 0, socket: 5, pid: 27649
[DEBUG] RECV [pid:27649](0 bytes):
[DEBUG] attempt result: found 0, redirect 1, location: https://redmine.cracksucht.de/my/page
[MOFOE] condition: Home
[MOFOE] str2: redmine.cracksucht.de
[MOFOE] str3: /my/page
[MOFOE] Page redirected to /my/page
[VERBOSE] Page redirected to http://redmine.cracksucht.de/my/page
DEBUG_DISCONNECT
DEBUG_CONNECT_OK
[VERBOSE] SSL negotiated cipher: ECDHE-RSA-AES256-SHA
[DEBUG] SEND [pid:27649](278 bytes):
0000:  4745 5420 2f6d 792f 7061 6765 2048 5454    [ GET /my/page HTT ]
0010:  502f 312e 300d 0a48 6f73 743a 2072 6564    [ P/1.0..Host: red ]
0020:  6d69 6e65 2e63 7261 636b 7375 6368 742e    [ mine.cracksucht. ]
0030:  6465 0d0a 5573 6572 2d41 6765 6e74 3a20    [ de..User-Agent:  ]
0040:  4d6f 7a69 6c6c 612f 342e 3020 2848 7964    [ Mozilla/4.0 (Hyd ]
0050:  7261 290d 0a43 6f6f 6b69 653a 205f 7265    [ ra)..Cookie: _re ]
...
[DEBUG] hydra_receive_line: waittime: 32, conwait: 0, socket: 5, pid: 27649
[DEBUG] RECV [pid:27649](1620 bytes):
0000:  4854 5450 2f31 2e30 2032 3030 204f 4b0d    [ HTTP/1.0 200 OK. ]
0010:  0a58 2d52 756e 7469 6d65 3a20 3836 0d0a    [ .X-Runtime: 86.. ]
0020:  5365 742d 436f 6f6b 6965 3a20 5f72 6564    [ Set-Cookie: _red ]
0030:  6d69 6e

Now it works as expected. 
I hope i didn't overlook something. 

regards,
morla
