### PR TITLE
included openssl missing headers

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,8 +3,8 @@ include $(CLEAR_VARS)
 
 LOCAL_CFLAGS:= -O3 -DLIBOPENSSL -DLIBFIREBIRD -DLIBIDN -DHAVE_PR29_H -DHAVE_PCRE \
                -DLIBMYSQLCLIENT -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH -DNO_RINDEX \
-               -DHAVE_MATH_H -DHAVE_MYSQL_H -DOPENSSL_NO_DEPRECATED -fdata-sections \
-               -ffunction-sections
+               -DHAVE_MATH_H -DHAVE_MYSQL_H -DOPENSSL_NO_DEPRECATED -DNO_RSA_LEGACY \
+               -fdata-sections -ffunction-sections
 
 LOCAL_LDFLAGS:=-Wl,--gc-sections
 

--- a/hydra-mod.c
+++ b/hydra-mod.c
@@ -3,6 +3,8 @@
 #ifdef LIBOPENSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
 #endif
 #ifdef HAVE_PCRE
 #include <pcre.h>

--- a/rdp.h
+++ b/rdp.h
@@ -551,6 +551,7 @@ enum RDP_UPDATE_PDU_TYPE
 #include <openssl/bn.h>
 #include <openssl/x509v3.h>
 #include <openssl/hmac.h>
+#include <openssl/rsa.h>
 
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x0090800f)
 #define D2I_X509_CONST const


### PR DESCRIPTION
android openssl headers does not automatically include `<openssl/rsa.h>`

other systems will try to include rsa.h again, but the initial

``` C
#ifndef HEADER_RSA_H
#define HEADER_RSA_H
...
```

will prevent including the header twice.
