### PR TITLE
Replace deprecated des_ and fix LibreSSL build

### DIFF
--- a/hydra-oracle-listener.c
+++ b/hydra-oracle-listener.c
@@ -106,7 +106,7 @@ int convert_byteorder(unsigned char **result, int size) {
 int ora_descrypt(unsigned char **rs, unsigned char *result, int siz) {
   int i = 0;
   char lastkey[8];
-  des_key_schedule ks1;
+  DES_key_schedule ks1;
   unsigned char key1[8] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
   unsigned char ivec1[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
   unsigned char *desresult;
@@ -116,17 +116,17 @@ int ora_descrypt(unsigned char **rs, unsigned char *result, int siz) {
     hydra_report(stderr, "[ERROR] Can't allocate memory\n");
     return 1;
   }
-  des_key_sched((C_Block *) key1, ks1);
-  des_ncbc_encrypt(result, desresult, siz, ks1, &ivec1, DES_ENCRYPT);
+  DES_key_sched((DES_cblock *) key1, ks1);
+  DES_ncbc_encrypt(result, desresult, siz, &ks1, &ivec1, DES_ENCRYPT);
 
   for (i = 0; i < 8; i++) {
     lastkey[i] = desresult[siz - 8 + i];
   }
 
-  des_key_sched((C_Block *) lastkey, ks1);
+  DES_key_sched((DES_cblock *) lastkey, ks1);
   memset(desresult, 0, siz);
   memset(ivec1, 0, sizeof(ivec1));
-  des_ncbc_encrypt(result, desresult, siz, ks1, &ivec1, DES_ENCRYPT);
+  DES_ncbc_encrypt(result, desresult, siz, &ks1, &ivec1, DES_ENCRYPT);
 
   if ((*rs = malloc(siz)) == NULL) {
     hydra_report(stderr, "[ERROR] Can't allocate memory\n");

--- a/hydra-smb.c
+++ b/hydra-smb.c
@@ -176,17 +176,17 @@ static void MakeKey(unsigned char *key, unsigned char *des_key) {
   des_key[6] = Get7Bits(key, 42);
   des_key[7] = Get7Bits(key, 49);
 
-  des_set_odd_parity((des_cblock *) des_key);
+  DES_set_odd_parity((DES_cblock *) des_key);
 }
 
 /* Do the DesEncryption */
 void DesEncrypt(unsigned char *clear, unsigned char *key, unsigned char *cipher) {
-  des_cblock des_key;
-  des_key_schedule key_schedule;
+  DES_cblock des_key;
+  DES_key_schedule key_schedule;
 
   MakeKey(key, des_key);
-  des_set_key(&des_key, key_schedule);
-  des_ecb_encrypt((des_cblock *) clear, (des_cblock *) cipher, key_schedule, 1);
+  DES_set_key(&des_key, &key_schedule);
+  DES_ecb_encrypt((DES_cblock *) clear, (DES_cblock *) cipher, &key_schedule, 1);
 }
 
 /*

--- a/hydra-snmp.c
+++ b/hydra-snmp.c
@@ -335,8 +335,8 @@ int start_snmp(int s, char *ip, int port, unsigned char options, char *miscptr, 
       // xor initVect with salt  
       for (i = 0; i < 8; i++)
         initVect[i] ^= privacy_params[i];
-      des_key_sched((C_Block *) key, symcbc);
-      des_ncbc_encrypt(snmpv3_get2 + 2, buf, sizeof(snmpv3_get2) - 2, symcbc, (C_Block *) (initVect), DES_ENCRYPT);
+      DES_key_sched((DES_cblock *) key, &symcbc);
+      DES_ncbc_encrypt(snmpv3_get2 + 2, buf, sizeof(snmpv3_get2) - 2, &symcbc, (DES_cblock *) (initVect), DES_ENCRYPT);
 
 #endif
 


### PR DESCRIPTION
uses deprecated des_ methods and types that were marked deprecated by
OpenSSL 0.9.7 and will be removed in OpenSSL 1.1.0 . This patch replaces
the des_ methods and types with their new DES_ counterparts. This
enables building with LibreSSL as OpenSSL library.

Check https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/des/des_old.h for the compatibility macros that have been removed.