### PR TITLE
Fix missing openssl library on android 6.0

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -91,11 +91,11 @@ LOCAL_STATIC_LIBRARIES := \
 	libapr-1 \
 	libaprutil-1 \
 	libiconv\
-	libneon
+	libneon\
+	libcrypto_static\
+	libssl_static
 						
 LOCAL_SHARED_LIBRARIES := \
-	libcrypto\
-	libssl\
 	libsqlite\
 	libexpat
 					

--- a/Android.mk
+++ b/Android.mk
@@ -2,8 +2,8 @@ LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_CFLAGS:= -O3 -DLIBOPENSSL -DLIBFIREBIRD -DLIBIDN -DHAVE_PR29_H -DHAVE_PCRE \
-               -DLIBMYSQLCLIENT -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH -DNO_RINDEX \
-               -DHAVE_MATH_H -DHAVE_MYSQL_H -DOPENSSL_NO_DEPRECATED -DNO_RSA_LEGACY \
+               -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH -DNO_RINDEX \
+               -DHAVE_MATH_H -DOPENSSL_NO_DEPRECATED -DNO_RSA_LEGACY \
                -fdata-sections -ffunction-sections          
 
 LOCAL_LDFLAGS:=-Wl,--gc-sections
@@ -13,7 +13,6 @@ LOCAL_C_INCLUDES:= \
 	external/openssl/include\
 	external/libssh/include\
 	external/libidn/lib\
-	external/libmysqlclient/include\
 	external/subversion/subversion/include\
 	external/apr/include\
 	external/firebird/include\
@@ -80,7 +79,6 @@ LOCAL_SRC_FILES:= \
 LOCAL_STATIC_LIBRARIES := \
 	libfbclient \
 	libidn \
-	libmysqlclient \
 	libncp \
 	libpcre \
 	libpcrecpp \

--- a/Android.mk
+++ b/Android.mk
@@ -93,7 +93,7 @@ LOCAL_STATIC_LIBRARIES := \
 	libiconv\
 	libneon\
 	libcrypto_static\
-	libssl_static
+	libssl
 						
 LOCAL_SHARED_LIBRARIES := \
 	libsqlite\

--- a/Android.mk
+++ b/Android.mk
@@ -57,6 +57,7 @@ LOCAL_SRC_FILES:= \
 	hydra-rexec.c\
 	hydra-rlogin.c\
 	hydra-rsh.c\
+	hydra-rtsp.c\
 	hydra-s7-300.c\
 	hydra-sapr3.c\
 	hydra-sip.c\


### PR DESCRIPTION
from android 6.0 google throw away the openssl library to use a lighter ssl library.

with this change openssl will be compiled statically into hydra, making it independent from underlay ssl implementation.