### PR TITLE
use static version of the ssl library

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,7 +1,7 @@
 LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS:= -O3 -DLIBOPENSSL -DLIBFIREBIRD -DLIBIDN -DHAVE_PR29_H -DHAVE_PCRE \
+LOCAL_CFLAGS:= -O3 -DLIBOPENSSL -DLIBIDN -DHAVE_PR29_H -DHAVE_PCRE \
                -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH -DNO_RINDEX \
                -DHAVE_MATH_H -DOPENSSL_NO_DEPRECATED -DNO_RSA_LEGACY \
                -fdata-sections -ffunction-sections          
@@ -15,7 +15,6 @@ LOCAL_C_INCLUDES:= \
 	external/libidn/lib\
 	external/subversion/subversion/include\
 	external/apr/include\
-	external/firebird/include\
 	external/libncp/include\
 	external/libpcre
 	
@@ -78,7 +77,6 @@ LOCAL_SRC_FILES:= \
 	sasl.c
 
 LOCAL_STATIC_LIBRARIES := \
-	libfbclient \
 	libidn \
 	libncp \
 	libpcre \

--- a/Android.mk
+++ b/Android.mk
@@ -91,8 +91,8 @@ LOCAL_STATIC_LIBRARIES := \
 	libaprutil-1 \
 	libiconv\
 	libneon\
-	libcrypto_static\
-	libssl
+	libssl_static\
+	libcrypto_static
 						
 LOCAL_SHARED_LIBRARIES := \
 	libsqlite\

--- a/hydra-rdp.c
+++ b/hydra-rdp.c
@@ -896,7 +896,7 @@ SSL_CERT *ssl_cert_read(uint8 * data, uint32 len) {
   return d2i_X509(NULL, (D2I_X509_CONST unsigned char **) &data, len);
 }
 
-void ssl_cert_free(SSL_CERT * cert) {
+static void ssl_cert_free(SSL_CERT * cert) {
   X509_free(cert);
 }
 


### PR DESCRIPTION
sorry for coming out later with these commits, I installed an android 6.0 emulator and tested out the whole stuff.

it should be `libssl_static`, not `libssl`, and it must be before `libcrypto_static`.

hydra define the function `ssl_cert_free`, that is also defined in openssl library.
solution to this problem is to define that function as file-scoped ( static ).

this will also fix hydra for anyone that want to build it statically with openssl library built-in.

thank you for your patience @vanhauser-thc :blush: 