### PR TITLE
Fix issue with hydra not compiling since adding custom ssl prefix

### DIFF
--- a/configure
+++ b/configure
@@ -149,7 +149,7 @@ if [ "X" != "X$DEBUG" ]; then
    echo DEBUG: SSL_INC=$INCDIRS `ls -d /*ssl/include /opt/*ssl/include /usr/*ssl/include /usr/local/*ssl/include 2> /dev/null`
 fi
 
-if [ "X" = "X$WSSL_LIB_PATH" ]; then
+if [ "X" != "X$WSSL_LIB_PATH" ]; then
     SSL_PATH="$i"
     CRYPTO_PATH="$i"
 else


### PR DESCRIPTION
As mentioned by users in #80, since adding the prefix the compilation is broken unless the SSL prefix is used.