### PR TITLE
If prefix set then high chance of libs being there

### DIFF
--- a/configure
+++ b/configure
@@ -127,6 +127,14 @@ if [ -d "/Library/Developer/CommandLineTools/usr/lib" ]; then
 fi
 LIBDIRS="$LIBDIRS /lib /usr/lib /usr/local/lib /opt/local/lib"
 INCDIRS="/usr/include /usr/local/include /opt/include /opt/local/include"
+if [ -n "$PREFIX" ]; then
+    if [ -d "$PREFIX/lib"]; then
+        LIBDIRS="$LIBDIRS $PREFIX/lib"
+    fi
+    if [ -d "$PREFIX/include"]; then
+        INCDIRS="$INCDIRS $PREFIX/include"
+    fi
+fi
 STRIP="strip"
 echo
 


### PR DESCRIPTION
If they are compiling to target an alternative directory there are likely dependencies to the same target.  Test for PREFIX/lib and PREFIX/include to be sure.