### PR TITLE
Sleeps are now interuptible and posix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ SRC = hydra-vnc.c hydra-pcnfs.c hydra-rexec.c hydra-nntp.c hydra-socks5.c \
       hydra-oracle.c hydra-vmauthd.c hydra-asterisk.c hydra-firebird.c hydra-afp.c hydra-ncp.c \
       hydra-oracle-sid.c hydra-http-proxy.c hydra-http-form.c hydra-irc.c \
       hydra-rdp.c hydra-s7-300.c hydra-redis.c \
-      crc32.c d3des.c bfg.c ntlm.c sasl.c hmacmd5.c hydra-mod.c hydra-rtsp.c
+      crc32.c d3des.c bfg.c ntlm.c sasl.c hmacmd5.c hydra-mod.c hydra-rtsp.c hydra-time.c
 OBJ = hydra-vnc.o hydra-pcnfs.o hydra-rexec.o hydra-nntp.o hydra-socks5.o \
       hydra-telnet.o hydra-cisco.o hydra-http.o hydra-ftp.o hydra-imap.o \
       hydra-pop3.o hydra-smb.o hydra-icq.o hydra-cisco-enable.o hydra-ldap.o \
@@ -30,7 +30,7 @@ OBJ = hydra-vnc.o hydra-pcnfs.o hydra-rexec.o hydra-nntp.o hydra-socks5.o \
       hydra-oracle-sid.o hydra-oracle.o hydra-vmauthd.o hydra-asterisk.o hydra-firebird.o hydra-afp.o hydra-ncp.o \
       hydra-http-proxy.o hydra-http-form.o hydra-irc.o hydra-redis.o \
       hydra-rdp.o hydra-s7-300.c \
-      crc32.o d3des.o bfg.o ntlm.o sasl.o hmacmd5.o hydra-mod.o hydra-rtsp.o
+      crc32.o d3des.o bfg.o ntlm.o sasl.o hmacmd5.o hydra-mod.o hydra-rtsp.o hydra-time.o
 BINS = hydra pw-inspector
 
 EXTRA_DIST = README README.arm README.palm CHANGES TODO INSTALL LICENSE \

--- a/hydra-asterisk.c
+++ b/hydra-asterisk.c
@@ -74,7 +74,7 @@ void service_asterisk(char *ip, int sp, unsigned char options, char *miscptr, FI
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-cisco-enable.c
+++ b/hydra-cisco-enable.c
@@ -74,7 +74,7 @@ void service_cisco_enable(char *ip, int sp, unsigned char options, char *miscptr
       {
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-cisco.c
+++ b/hydra-cisco.c
@@ -132,7 +132,7 @@ void service_cisco(char *ip, int sp, unsigned char options, char *miscptr, FILE 
 
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-cvs.c
+++ b/hydra-cvs.c
@@ -104,7 +104,7 @@ void service_cvs(char *ip, int sp, unsigned char options, char *miscptr, FILE * 
       if (sock >= 0)
         sock = hydra_disconnect(sock);
 
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-ftp.c
+++ b/hydra-ftp.c
@@ -84,7 +84,7 @@ void service_ftp_core(char *ip, int sp, unsigned char options, char *miscptr, FI
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;
@@ -101,7 +101,7 @@ void service_ftp_core(char *ip, int sp, unsigned char options, char *miscptr, FI
           hydra_report(stderr, "[ERROR] Child with pid %d terminating, can not connect\n", (int) getpid());
         hydra_child_exit(1);
       }
-      usleep(250);
+      usleepn(250);
       buf = hydra_receive_line(sock);
       if (buf == NULL || buf[0] != '2') {       /* check the first line */
         if (verbose || debug)

--- a/hydra-http-proxy-urlenum.c
+++ b/hydra-http-proxy-urlenum.c
@@ -243,7 +243,7 @@ void service_http_proxy_urlenum(char *ip, int sp, unsigned char options, char *m
       {
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-http-proxy.c
+++ b/hydra-http-proxy.c
@@ -263,7 +263,7 @@ void service_http_proxy(char *ip, int sp, unsigned char options, char *miscptr, 
           free(http_proxy_buf);
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-imap.c
+++ b/hydra-imap.c
@@ -19,7 +19,7 @@ char *imap_read_server_capacity(int sock) {
     if (buf != NULL) {
       if (strstr(buf, "CAPABILITY") != NULL && buf[0] == '*') {
         resp = 1;
-        usleep(300000);
+        sleepn(300);
         /* we got the capability info then get the completed warning info from server */
         while (hydra_data_ready(sock)) {
           free(buf);
@@ -362,7 +362,7 @@ void service_imap(char *ip, int sp, unsigned char options, char *miscptr, FILE *
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(275000);
+//      sleepn(275);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-irc.c
+++ b/hydra-irc.c
@@ -63,7 +63,7 @@ int send_nick(int s, char *ip, char *pass) {
 int irc_server_connect(char *ip, int sock, int port, unsigned char options) {
   if (sock >= 0)
     sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
   if ((options & OPTION_SSL) == 0) {
     if (port != 0)
       myport = port;

--- a/hydra-ldap.c
+++ b/hydra-ldap.c
@@ -363,7 +363,7 @@ void service_ldap(char *ip, int sp, unsigned char options, char *miscptr, FILE *
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(275000);
+//      sleepn(275);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-mod.c
+++ b/hydra-mod.c
@@ -576,7 +576,7 @@ void hydra_child_exit(int code) {
     __fck = write(intern_socket, "E", 1);
   }
   do {
-    usleep(10000);
+    sleepn(10);
   } while (read(intern_socket, buf, 1) <= 0);
 //  sleep(2); // be sure that mommy receives our message
   exit(0);                      // might be killed before reaching this
@@ -920,7 +920,7 @@ char *hydra_receive_line(int socket) {
         if (buff[k] == 0)
           buff[k] = 32;
       buff[got] = 0;
-      usleep(100);
+      usleepn(100);
     }
   }
 
@@ -940,7 +940,7 @@ char *hydra_receive_line(int socket) {
       got += j;
       buff[got] = 0;
     }
-    usleep(100);
+    usleepn(100);
   }
 
   if (debug) {

--- a/hydra-mysql.c
+++ b/hydra-mysql.c
@@ -322,7 +322,7 @@ void service_mysql(char *ip, int sp, unsigned char options, char *miscptr, FILE 
         hydra_mysql_send_com_quit(sock);
         sock = hydra_disconnect(sock);
       }
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-nntp.c
+++ b/hydra-nntp.c
@@ -272,7 +272,7 @@ void service_nntp(char *ip, int sp, unsigned char options, char *miscptr, FILE *
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;
@@ -289,7 +289,7 @@ void service_nntp(char *ip, int sp, unsigned char options, char *miscptr, FILE *
           hydra_report(stderr, "[ERROR] Child with pid %d terminating, can not connect\n", (int) getpid());
         hydra_child_exit(1);
       }
-//      usleep(300000);
+//      sleepn(300);
       buf = hydra_receive_line(sock);
       if (buf == NULL || buf[0] != '2') {       /* check the first line */
         if (verbose || debug)
@@ -445,7 +445,7 @@ SASL PLAIN DIGEST-MD5 LOGIN NTLM CRAM-MD5
           break;
         }
       }
-      usleep(25000);
+      sleepn(25);
       free(buf);
       next_run = 2;
       break;

--- a/hydra-oracle-listener.c
+++ b/hydra-oracle-listener.c
@@ -287,7 +287,7 @@ void service_oracle_listener(char *ip, int sp, unsigned char options, char *misc
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-oracle-sid.c
+++ b/hydra-oracle-sid.c
@@ -97,7 +97,7 @@ void service_oracle_sid(char *ip, int sp, unsigned char options, char *miscptr, 
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-pcanywhere.c
+++ b/hydra-pcanywhere.c
@@ -238,7 +238,7 @@ void service_pcanywhere(char *ip, int sp, unsigned char options, char *miscptr, 
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-      usleep(275000);
+      sleepn(275);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-pcnfs.c
+++ b/hydra-pcnfs.c
@@ -159,7 +159,7 @@ void service_pcnfs(char *ip, int sp, unsigned char options, char *miscptr, FILE 
       {
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((sock = hydra_connect_udp(ip, port)) < 0) {
           if (quiet != 1) fprintf(stderr, "[ERROR] Child with pid %d terminating, can not connect\n", (int) getpid());
           hydra_child_exit(1);

--- a/hydra-pop3.c
+++ b/hydra-pop3.c
@@ -432,7 +432,7 @@ void service_pop3(char *ip, int sp, unsigned char options, char *miscptr, FILE *
 
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-      //      usleep(300000);
+      //      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         sock = hydra_connect_tcp(ip, port);
       } else {
@@ -519,7 +519,7 @@ int service_pop3_init(char *ip, int sp, unsigned char options, char *miscptr, FI
 
   if (sock >= 0)
     sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
   if ((options & OPTION_SSL) == 0) {
     if (port != 0)
       myport = port;

--- a/hydra-postgres.c
+++ b/hydra-postgres.c
@@ -80,7 +80,7 @@ void service_postgres(char *ip, int sp, unsigned char options, char *miscptr, FI
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//                              usleep(275000);
+//                              sleepn(275);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-redis.c
+++ b/hydra-redis.c
@@ -62,7 +62,7 @@ void service_redis_core(char *ip, int sp, unsigned char options, char *miscptr, 
           hydra_report(stderr, "[ERROR] Child with pid %d terminating, can not connect\n", (int) getpid());
         hydra_child_exit(1);
       }
-      usleep(250);
+      usleepn(250);
       next_run = 2;
       break;
     case 2:                    /* run the cracking function */

--- a/hydra-rexec.c
+++ b/hydra-rexec.c
@@ -59,7 +59,7 @@ void service_rexec(char *ip, int sp, unsigned char options, char *miscptr, FILE 
       {
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-rlogin.c
+++ b/hydra-rlogin.c
@@ -106,7 +106,7 @@ void service_rlogin(char *ip, int sp, unsigned char options, char *miscptr, FILE
         hydra_set_srcport(1023);
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-rsh.c
+++ b/hydra-rsh.c
@@ -76,7 +76,7 @@ void service_rsh(char *ip, int sp, unsigned char options, char *miscptr, FILE * 
         hydra_set_srcport(1023);
         if (sock >= 0)
           sock = hydra_disconnect(sock);
-//        usleep(275000);
+//        sleepn(275);
         if ((options & OPTION_SSL) == 0) {
           if (port != 0)
             myport = port;

--- a/hydra-smb.c
+++ b/hydra-smb.c
@@ -1375,7 +1375,7 @@ void service_smb(char *ip, int sp, unsigned char options, char *miscptr, FILE * 
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
 
       if (port != 0) {
         sock = hydra_connect_tcp(ip, port);

--- a/hydra-socks5.c
+++ b/hydra-socks5.c
@@ -119,7 +119,7 @@ void service_socks5(char *ip, int sp, unsigned char options, char *miscptr, FILE
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-svn.c
+++ b/hydra-svn.c
@@ -152,7 +152,7 @@ void service_svn(char *ip, int sp, unsigned char options, char *miscptr, FILE * 
       if (sock >= 0)
         sock = hydra_disconnect(sock);
 
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-teamspeak.c
+++ b/hydra-teamspeak.c
@@ -116,7 +116,7 @@ void service_teamspeak(char *ip, int sp, unsigned char options, char *miscptr, F
     case 1:                    /* connect and service init function */
 //      if (sock >= 0)
 //      sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if (sock < 0) {
         if (port != 0)
           myport = port;

--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -24,7 +24,7 @@ int start_telnet(int s, char *ip, int port, unsigned char options, char *miscptr
       } else {
         send(s, &buffer[i], 1, 0);
       }
-      usleep(20000);
+      sleepn(20);
     }
   } else {
     if (hydra_send(s, buffer, strlen(buffer) + 1, 0) < 0) {
@@ -66,7 +66,7 @@ int start_telnet(int s, char *ip, int port, unsigned char options, char *miscptr
       } else {
         send(s, &buffer[i], 1, 0);
       }
-      usleep(20000);
+      sleepn(20);
     }
   } else {
     if (hydra_send(s, buffer, strlen(buffer) + 1, 0) < 0) {
@@ -112,7 +112,7 @@ void service_telnet(char *ip, int sp, unsigned char options, char *miscptr, FILE
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       no_line_mode = 0;
       first = 0;
       if ((options & OPTION_SSL) == 0) {

--- a/hydra-time.c
+++ b/hydra-time.c
@@ -1,8 +1,7 @@
-
-#include <time.h>
-
 #include "hydra.h"
 
+#ifndef _WIN32
+#include <time.h>
 int sleepn(time_t seconds)
 {
 	struct timespec ts;
@@ -10,10 +9,23 @@ int sleepn(time_t seconds)
 	ts.tv_nsec = 0;
    return nanosleep(&ts, NULL);
 }
-
 int usleepn(long int milisec) {
 	struct timespec ts;
 	ts.tv_sec = milisec / 1000;
 	ts.tv_nsec = (milisec % 1000) * 1000000L;
 	return nanosleep(&ts, NULL);
 }
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+int sleepn(unsigned int seconds) 
+{
+ return SleepEx(milisec*1000,TRUE);
+}
+
+int usleepn(unsigned int milisec) 
+{
+ return SleepEx(milisec,TRUE);
+}
+#endif

--- a/hydra-time.c
+++ b/hydra-time.c
@@ -1,0 +1,19 @@
+
+#include <time.h>
+
+#include "hydra.h"
+
+int sleepn(time_t seconds)
+{
+	struct timespec ts;
+	ts.tv_sec = seconds;
+	ts.tv_nsec = 0;
+   return nanosleep(&ts, NULL);
+}
+
+int usleepn(long int milisec) {
+	struct timespec ts;
+	ts.tv_sec = milisec / 1000;
+	ts.tv_nsec = (milisec % 1000) * 1000000L;
+	return nanosleep(&ts, NULL);
+}

--- a/hydra-vmauthd.c
+++ b/hydra-vmauthd.c
@@ -77,7 +77,7 @@ void service_vmauthd(char *ip, int sp, unsigned char options, char *miscptr, FIL
     case 1:                    /* connect and service init function */
       if (sock >= 0)
         sock = hydra_disconnect(sock);
-//      usleep(300000);
+//      sleepn(300);
       if ((options & OPTION_SSL) == 0) {
         if (port != 0)
           myport = port;

--- a/hydra-vnc.c
+++ b/hydra-vnc.c
@@ -170,7 +170,7 @@ void service_vnc(char *ip, int sp, unsigned char options, char *miscptr, FILE * 
         hydra_report(stderr, "[ERROR] Child with pid %d terminating, can not connect\n", (int) getpid());
         hydra_child_exit(1);
       }
-      usleep(300000);
+      sleepn(300);
       buf = hydra_receive_line(sock);
 
       if (buf == NULL || (strncmp(buf, "RFB", 3) != 0)) {       /* check the first line */

--- a/hydra-xmpp.c
+++ b/hydra-xmpp.c
@@ -47,7 +47,7 @@ int start_xmpp(int s, char *ip, int port, unsigned char options, char *miscptr, 
   }
 
   hydra_send(s, buffer, strlen(buffer), 0);
-  usleep(300000);
+  sleepn(300);
   if ((buf = hydra_receive_line(s)) == NULL)
     return 3;
 
@@ -244,7 +244,7 @@ int start_xmpp(int s, char *ip, int port, unsigned char options, char *miscptr, 
     if (hydra_send(s, buffer, strlen(buffer), 0) < 0) {
       return 1;
     }
-    usleep(50000);
+    sleepn(50);
     buf = hydra_receive_line(s);
     if (buf == NULL)
       return 1;
@@ -334,7 +334,7 @@ void service_xmpp(char *target, char *ip, int sp, unsigned char options, char *m
         hydra_child_exit(1);
       }
       //some server is longer to answer
-      usleep(300000);
+      sleepn(300);
       do {
         if ((buf = hydra_receive_line(sock)) == NULL) {
           /* no auth method identified */
@@ -435,7 +435,7 @@ void service_xmpp(char *target, char *ip, int sp, unsigned char options, char *m
         char *STARTTLS = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>";
 
         hydra_send(sock, STARTTLS, strlen(STARTTLS), 0);
-        usleep(300000);
+        sleepn(300);
         buf = hydra_receive_line(sock);
 
         if (buf == NULL || strstr(buf, "<failure") != NULL) {
@@ -460,7 +460,7 @@ void service_xmpp(char *target, char *ip, int sp, unsigned char options, char *m
             hydra_child_exit(1);
           }
           //some server is longer to answer
-          usleep(300000);
+          sleepn(300);
           buf = hydra_receive_line(sock);
           if ((buf == NULL) || (strstr(buf, "<stream:stream") == NULL))
             hydra_child_exit(1);

--- a/hydra.c
+++ b/hydra.c
@@ -3876,7 +3876,7 @@ int main(int argc, char *argv[]) {
       }
     }
 
-    usleep(USLEEP_LOOP);
+    usleepn(USLEEP_LOOP);
     (void) wait3(NULL, WNOHANG, NULL);
     // write restore file and report status 
     if (process_restore == 1 && time(NULL) - elapsed_restore > 299) {

--- a/hydra.h
+++ b/hydra.h
@@ -132,5 +132,9 @@
 #define INET_ADDRSTRLEN 16
 #endif
 
+int sleepn(time_t seconds);
+
+int usleepn(long int useconds);
+
 #define _HYDRA_H
 #endif

--- a/hydra.h
+++ b/hydra.h
@@ -132,9 +132,19 @@
 #define INET_ADDRSTRLEN 16
 #endif
 
-int sleepn(time_t seconds);
+#ifndef _WIN32
 
+int sleepn(time_t seconds);
 int usleepn(long int useconds);
+
+#endif
+
+#ifdef _WIN32
+
+int sleepn(unsigned int seconds);
+int usleepn(unsigned int useconds);
+
+#endif
 
 #define _HYDRA_H
 #endif


### PR DESCRIPTION
usleep is now depricated and is uninteruptable.  nanosleep is considered the suggested replacement.  Unfortunately it isn't available in Windows but by writing seperate code we can add Window's interuptable SleepEx function.

nanosleep also can take seconds directly so there is an addition function written for that.