### PR TITLE
ssh disconnect miss bug fixed

### DIFF
--- a/hydra-ssh.c
+++ b/hydra-ssh.c
@@ -80,7 +80,7 @@ int start_ssh(int s, char *ip, int port, unsigned char options, char *miscptr, F
     return 4;
   }
 
-  if (auth_state == SSH_AUTH_ERROR) {
+  if (auth_state == SSH_AUTH_ERROR || !ssh_is_connected(session)) {
     new_session = 1;
     return 1;
   }


### PR DESCRIPTION
The problem was detected while trying to brute ssh server. 
Once hydra reached limit in 6 attempts (default MaxAuthTries value for sshd), server disconnected it, but hydra didn't reconnect to ssh and kept trying next passwords in closed session. When i checked sshd logs, i saw that there wasn't any login attempts after first disconnect.
This bug caused the problem: hydra hadn't crack ssh, even if correct password was in dictionary. 

As said on [libssh docs](http://api.libssh.org/stable/group__libssh__auth.html), userauth functions return SSH_AUTH_ERROR only in case of serious problems, it means that disconnect is standard situation and should be checked using ssh_is_connected(session) function.

