### PR TITLE
Add 'http-post', remove HTTP 403 as success criteria

### DIFF
--- a/hydra-http.c
+++ b/hydra-http.c
@@ -192,7 +192,9 @@ int start_http(int s, char *ip, int port, unsigned char options, char *miscptr, 
   ptr = ((char *) index(http_buf, ' '));
   if (ptr != NULL)
     ptr++;
-  if (ptr != NULL && (*ptr == '2' || *ptr == '3' || strncmp(ptr, "403", 3) == 0 || strncmp(ptr, "404", 3) == 0)) {
+// Make this optional
+//  if (ptr != NULL && (*ptr == '2' || *ptr == '3' || strncmp(ptr, "403", 3) == 0 || strncmp(ptr, "404", 3) == 0)) {
+  if (ptr != NULL && (*ptr == '2' || *ptr == '3' || strncmp(ptr, "404", 3) == 0)) {
     hydra_report_found_host(port, ip, "www", fp);
     hydra_completed_pair_found();
     if (http_buf != NULL) {
@@ -325,6 +327,10 @@ void service_http_get(char *ip, int sp, unsigned char options, char *miscptr, FI
 
 void service_http_head(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port) {
   service_http(ip, sp, options, miscptr, fp, port, "HEAD");
+}
+
+void service_http_post(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port) {
+  service_http(ip, sp, options, miscptr, fp, port, "POST");
 }
 
 int service_http_init(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port) {

--- a/hydra.c
+++ b/hydra.c
@@ -31,6 +31,7 @@ extern void service_rsh(char *ip, int sp, unsigned char options, char *miscptr, 
 extern void service_nntp(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
 extern void service_http_head(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
 extern void service_http_get(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
+extern void service_http_post(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
 extern void service_http_get_form(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
 extern void service_http_post_form(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
 extern void service_icq(char *ip, int sp, unsigned char options, char *miscptr, FILE * fp, int port);
@@ -142,7 +143,7 @@ extern int service_rtsp_init(char *ip, int sp, unsigned char options, char *misc
 
 // ADD NEW SERVICES HERE
 char *SERVICES =
-  "asterisk afp cisco cisco-enable cvs firebird ftp ftps http[s]-{head|get} http[s]-{get|post}-form http-proxy http-proxy-urlenum icq imap[s] irc ldap2[s] ldap3[-{cram|digest}md5][s] mssql mysql ncp nntp oracle oracle-listener oracle-sid pcanywhere pcnfs pop3[s] postgres rdp redis rexec rlogin rsh rtsp s7-300 sapr3 sip smb smtp[s] smtp-enum snmp socks5 ssh sshkey svn teamspeak telnet[s] vmauthd vnc xmpp";
+  "asterisk afp cisco cisco-enable cvs firebird ftp ftps http[s]-{head|get|post} http[s]-{get|post}-form http-proxy http-proxy-urlenum icq imap[s] irc ldap2[s] ldap3[-{cram|digest}md5][s] mssql mysql ncp nntp oracle oracle-listener oracle-sid pcanywhere pcnfs pop3[s] postgres rdp redis rexec rlogin rsh rtsp s7-300 sapr3 sip smb smtp[s] smtp-enum snmp socks5 ssh sshkey svn teamspeak telnet[s] vmauthd vnc xmpp";
 
 #define MAXBUF       520
 #define MAXLINESIZE  ( ( MAXBUF / 2 ) - 4 )
@@ -1132,7 +1133,7 @@ void hydra_service_init(int target_no) {
     x = service_ftp_init(hydra_targets[target_no]->ip, -1, options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
   if (strcmp(hydra_options.service, "redis") == 0 || strcmp(hydra_options.service, "redis") == 0)
     x = service_redis_init(hydra_targets[target_no]->ip, -1, options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
-  if (strcmp(hydra_options.service, "http-get") == 0 || strcmp(hydra_options.service, "http-head") == 0)
+  if (strcmp(hydra_options.service, "http-get") == 0 || strcmp(hydra_options.service, "http-head") == 0 || strcmp(hydra_options.service, "http-post") == 0)
     x = service_http_init(hydra_targets[target_no]->ip, -1, options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
   if (strcmp(hydra_options.service, "http-form") == 0 || strcmp(hydra_options.service, "http-get-form") == 0 || strcmp(hydra_options.service, "http-post-form") == 0)
     x = service_http_form_init(hydra_targets[target_no]->ip, -1, options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
@@ -1316,6 +1317,8 @@ int hydra_spawn_head(int head_no, int target_no) {
         service_ldap3(hydra_targets[target_no]->ip, hydra_heads[head_no]->sp[1], options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
       if (strcmp(hydra_options.service, "http-head") == 0)
         service_http_head(hydra_targets[target_no]->ip, hydra_heads[head_no]->sp[1], options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
+      if (strcmp(hydra_options.service, "http-post") == 0)
+        service_http_post(hydra_targets[target_no]->ip, hydra_heads[head_no]->sp[1], options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
       if (strcmp(hydra_options.service, "ldap3-crammd5") == 0)
         service_ldap3_cram_md5(hydra_targets[target_no]->ip, hydra_heads[head_no]->sp[1], options, hydra_options.miscptr, hydra_brains.ofp, hydra_targets[target_no]->port);
       if (strcmp(hydra_options.service, "ldap3-digestmd5") == 0)
@@ -1470,6 +1473,7 @@ int hydra_lookup_port(char *service) {
     {"ftp", PORT_FTP, PORT_FTP_SSL},
     {"ftps", PORT_FTP, PORT_FTP_SSL},
     {"http-head", PORT_HTTP, PORT_HTTP_SSL},
+    {"http-post", PORT_HTTP, PORT_HTTP_SSL},
     {"http-get", PORT_HTTP, PORT_HTTP_SSL},
     {"http-get-form", PORT_HTTP, PORT_HTTP_SSL},
     {"http-post-form", PORT_HTTP, PORT_HTTP_SSL},
@@ -2460,7 +2464,7 @@ int main(int argc, char *argv[]) {
     // stuff we have to copy from the non-restore part
     if (strncmp(hydra_options.service, "http-", 5) == 0) {
       if (getenv("HYDRA_PROXY_HTTP") && getenv("HYDRA_PROXY"))
-        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get!");
+        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get/http-post!");
       if (getenv("HYDRA_PROXY_HTTP")) {
         printf("[INFO] Using HTTP Proxy: %s\n", getenv("HYDRA_PROXY_HTTP"));
         use_proxy = 1;
@@ -2580,7 +2584,7 @@ int main(int argc, char *argv[]) {
 
     if (strcmp(hydra_options.service, "ssl") == 0 || strcmp(hydra_options.service, "www") == 0 || strcmp(hydra_options.service, "http") == 0
         || strcmp(hydra_options.service, "https") == 0) {
-      fprintf(stderr, "[WARNING] The service http has been replaced with http-head and http-get, using by default GET method. Same for https.\n");
+      fprintf(stderr, "[WARNING] The service http has been replaced with http-head/http-get/http-post using by default GET method. Same for https.\n");
       if (strcmp(hydra_options.service, "http") == 0) {
         hydra_options.service = malloc(strlen("http-get") + 1);
         strcpy(hydra_options.service, "http-get");
@@ -2930,19 +2934,22 @@ int main(int argc, char *argv[]) {
       if (hydra_options.tasks > 4)
         fprintf(stderr, "[WARNING] you should set the number of parallel task to 4 for vnc services.\n");
     }
-    if (strcmp(hydra_options.service, "https-head") == 0 || strcmp(hydra_options.service, "https-get") == 0) {
+    if (strcmp(hydra_options.service, "https-head") == 0 || strcmp(hydra_options.service, "https-get") == 0 || strcmp(hydra_options.service, "https-post") == 0) {
 #ifdef LIBOPENSSL
       i = 1;
       hydra_options.ssl = 1;
       if (strcmp(hydra_options.service, "https-head") == 0)
         strcpy(hydra_options.service, "http-head");
-      else
+      else if (strcmp(hydra_options.service, "https-get") == 0)
         strcpy(hydra_options.service, "http-get");
+      else
+        strcpy(hydra_options.service, "http-post");
+      
 #else
       bail("Compiled without SSL support, module not available");
 #endif
     }
-    if (strcmp(hydra_options.service, "http-get") == 0 || strcmp(hydra_options.service, "http-head") == 0) {
+    if (strcmp(hydra_options.service, "http-get") == 0 || strcmp(hydra_options.service, "http-head") == 0 || strcmp(hydra_options.service, "http-post") == 0) {
       i = 1;
       if (hydra_options.miscptr == NULL) {
         fprintf(stderr, "[WARNING] You must supply the web page as an additional option or via -m, default path set to /\n");
@@ -2952,7 +2959,7 @@ int main(int argc, char *argv[]) {
       if (*hydra_options.miscptr != '/' && strstr(hydra_options.miscptr, "://") == NULL)
         bail("The web page you supplied must start with a \"/\", \"http://\" or \"https://\", e.g. \"/protected/login\"");
       if (getenv("HYDRA_PROXY_HTTP") && getenv("HYDRA_PROXY"))
-        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get!");
+        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get/http-post!");
       if (getenv("HYDRA_PROXY_HTTP")) {
         printf("[INFO] Using HTTP Proxy: %s\n", getenv("HYDRA_PROXY_HTTP"));
         use_proxy = 1;
@@ -2989,7 +2996,7 @@ int main(int argc, char *argv[]) {
       if (hydra_options.miscptr[0] != '/')
         bail("optional parameter must start with a '/' slash!\n");
       if (getenv("HYDRA_PROXY_HTTP") && getenv("HYDRA_PROXY"))
-        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get!");
+        bail("Found HYDRA_PROXY_HTTP *and* HYDRA_PROXY environment variables - you can use only ONE for the service http-head/http-get/http-post!");
       if (getenv("HYDRA_PROXY_HTTP")) {
         printf("[INFO] Using HTTP Proxy: %s\n", getenv("HYDRA_PROXY_HTTP"));
         use_proxy = 1;


### PR DESCRIPTION
This is a bit of a hack and I could use some feedback rather than a merge here. I was testing a device that needed HTTP POST (no data) for the 401 response and sent back a 403 on error. This feels like it should be a bigger patch to make all of this configurable, but it works for me (tm) at the moment.

Happy to keep this as a side thing, but also up for a rework to make this configurable if there is any desire. 

Thoughts?

Thanks!