### PR TITLE
SunOS compile support

### DIFF
--- a/configure
+++ b/configure
@@ -1220,6 +1220,10 @@ if [ "X" != "X$DEBUG" ]; then
    echo DEBUG: STRIP=$STRIP
 fi
 
+if [ "$SYSS" = "SunOS" ]; then
+   XLIBS="$XLIBS -lrt"
+fi
+
 echo "Writing Makefile.in ..."
 if [ "X" != "X$FHS" ]; then
   echo "MANDIR = /share/man/man1" >> Makefile.in
@@ -1263,7 +1267,7 @@ if [ "x$WINDRES" = "x" ]; then
   echo HYDRA_LOGO= >> Makefile
   echo PWI_LOGO= >> Makefile
 fi
-if [ "$GCCSEC" = "yes" ]; then
+if [ "$GCCSEC" = "yes" ] && [ "$SYSS" != "SunOS" ]; then
   echo "SEC=$GCCSECOPT" >> Makefile
 else
   echo "SEC=" >> Makefile

--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -114,6 +114,27 @@ ptr_header_node header_exists(ptr_header_node * ptr_head, char *header_name, cha
   return found_header;
 }
 
+#if defined(__sun)
+/* Written by Kaveh R. Ghazi <ghazi@caip.rutgers.edu> */
+char *
+strndup (const char *s, size_t n)
+{
+  char *result;
+  size_t len = strlen (s);
+
+  if (n < len)
+    len = n;
+
+  result = (char *) malloc (len + 1);
+  if (!result)
+    return 0;
+
+  memcpy (result, s, len);
+  result[len] = '\0';
+  return(result);
+}
+#endif
+
 int append_cookie(char *name, char *value, ptr_cookie_node *last_cookie)
 {
 	ptr_cookie_node new_ptr = (ptr_cookie_node) malloc(sizeof(t_cookie_node));


### PR DESCRIPTION
changes summary

```
remove GCCSEC options to compile on sunos
add -lrt to support nanosleep()
add definition of strndup()
```