### PR TITLE
Remove rindex() and always use strrchr()

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_CFLAGS:= -O3 -DLIBOPENSSL -DLIBIDN -DHAVE_PR29_H -DHAVE_PCRE \
-               -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH -DNO_RINDEX \
+               -DLIBNCP -DLIBPOSTGRES -DLIBSVN -DLIBSSH \
                -DHAVE_MATH_H -DOPENSSL_NO_DEPRECATED -DNO_RSA_LEGACY \
                -fdata-sections -ffunction-sections          
 

--- a/configure
+++ b/configure
@@ -966,14 +966,6 @@ fi
 
 echo "Checking for Android specialities ..."
 TMPC=comptest$$
-RINDEX=" not"
-echo '#include <stdio.h>' > $TMPC.c
-echo '#include <strings.h>' >> $TMPC.c
-echo "int main() { char *x = rindex(\"test\", 'e'); if (x == NULL) return 0; else return 1; }" >> $TMPC.c
-gcc -o $TMPC $TMPC.c > /dev/null 2>&1
-test -x $TMPC && RINDEX=""
-rm -f $TMPC $TMPC.c
-echo "                                  ... rindex()$RINDEX found"
 if [ -n "$CRYPTO_PATH" ]; then
   RSA=" not"
   echo '#include <stdio.h>' > $TMPC.c
@@ -1059,9 +1051,6 @@ if [ -n "$SVN_PATH" ]; then
 fi
 if [ -n "$SSH_PATH" ]; then
     XDEFINES="$XDEFINES -DLIBSSH"
-fi
-if [ -n "$RINDEX" ]; then
-    XDEFINES="$XDEFINES -DNO_RINDEX"
 fi
 if [ -n "$RSA" ]; then
     XDEFINES="$XDEFINES -DNO_RSA_LEGACY"

--- a/hydra-nntp.c
+++ b/hydra-nntp.c
@@ -32,11 +32,7 @@ char *nntp_read_server_capacity(int sock) {
           buf[strlen(buf) - 1] = 0;
         if (buf[strlen(buf) - 1] == '\r')
           buf[strlen(buf) - 1] = 0;
-#ifdef NO_RINDEX
         if ((ptr = strrchr(buf, '\n')) != NULL) {
-#else
-        if ((ptr = rindex(buf, '\n')) != NULL) {
-#endif
           ptr++;
           if (isdigit((int) *ptr) && *(ptr + 3) == ' ')
             resp = 1;

--- a/hydra-smtp.c
+++ b/hydra-smtp.c
@@ -21,11 +21,7 @@ char *smtp_read_server_capacity(int sock) {
           buf[strlen(buf) - 1] = 0;
         if (buf[strlen(buf) - 1] == '\r')
           buf[strlen(buf) - 1] = 0;
-#ifdef NO_RINDEX
         if ((ptr = strrchr(buf, '\n')) != NULL) {
-#else
-        if ((ptr = rindex(buf, '\n')) != NULL) {
-#endif
           ptr++;
           if (isdigit((int) *ptr) && *(ptr + 3) == ' ')
             resp = 1;


### PR DESCRIPTION
The rindex() function was deprecated a long time ago and using strrchr() nowadays is safe, so maintaining a rindex() path is just unnecessary complexity.

Also, this fixes a build issue when cross compiling for Android using a standalone toolchain, as the probing in configure for rindex() uses the native gcc instead of the cross compiler.