### PR TITLE
Fix manpage adding a missing newline

### DIFF
--- a/hydra.1
+++ b/hydra.1
@@ -105,6 +105,7 @@ prefer IPv4 (default) or IPv6 addresses
 .TP
 .B \-v / \-V 
 verbose mode / show login+pass combination for each attempt
+.TP
 .B \-d
 debug mode
 .TP


### PR DESCRIPTION
A missing newline lead to https://bugs.debian.org/853807