### PR TITLE
do not assume sizeof(int) is the pointer size

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -967,7 +967,7 @@ void hydra_restore_read() {
   }
   if (debug)
     printf("[DEBUG] reading restore file: Step 11 complete\n");
-  hydra_heads = malloc((hydra_options.max_use + 2) * sizeof(int) + 16);
+  hydra_heads = malloc(sizeof(hydra_head*) * hydra_options.max_use);
   for (j = 0; j < hydra_options.max_use; j++) {
     hydra_heads[j] = malloc(sizeof(hydra_head));
     fck = (int) fread(hydra_heads[j], sizeof(hydra_head), 1, f);
@@ -3583,7 +3583,7 @@ int main(int argc, char *argv[]) {
        if (tmpptr != NULL)
          *tmpptr = 0;
        countservers = hydra_brains.targets = 1;
-       hydra_targets = malloc(sizeof(int) * 4);
+       hydra_targets = malloc(sizeof(hydra_target*) * 4);
        hydra_targets[0] = malloc(sizeof(hydra_target));
        memset(hydra_targets[0], 0, sizeof(hydra_target));
        hydra_targets[0]->target = servers_ptr = hydra_options.server;
@@ -3641,7 +3641,7 @@ int main(int argc, char *argv[]) {
      }
     } else {                    // standard: single target on command line
       countservers = hydra_brains.targets = 1;
-      hydra_targets = malloc(sizeof(int) * 4);
+      hydra_targets = malloc(sizeof(hydra_target*) * 4);
       hydra_targets[0] = malloc(sizeof(hydra_target));
       memset(hydra_targets[0], 0, sizeof(hydra_target));
       hydra_targets[0]->target = servers_ptr = hydra_options.server;


### PR DESCRIPTION
sizeof(int) is not necessarily the same as the pointer size. On my amd64
system sizeof(int) is 4 bytes while the pointer size is 8 bytes. The
change solves https://github.com/vanhauser-thc/thc-hydra/issues/27 for
me.