### PR TITLE
Reset redirect flag and fix redirect port error issue

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -468,7 +468,8 @@ return -1 if no response from server
 */
 int analyze_server_response(int s) {
   int runs = 0;
-
+  redirected_flag = 0;
+  auth_flag = 0;
   while ((buf = hydra_receive_line(s)) != NULL) {
     runs++;
     //check for http redirection
@@ -846,6 +847,10 @@ int start_http_form(int s, char *ip, int port, unsigned char options, char *misc
         for (i = j; i > 0; i--)
           str3[i] = str3[i - 1];
         str3[0] = '/';
+      }
+
+      if(strrchr(url, ':') == NULL && port != 80) {
+        sprintf(str2, "%s:%d", str2, port);
       }
 
       if (verbose)


### PR DESCRIPTION
fix following 2 issues:

1. when fail is a redirect url, matched is not - but the redirect flag is still 1 - causing match missed

2. when redirect to a relative url on a port not 80, it fails to attach the port to the redirect url