### PR TITLE
add radmin2 to xhydra selection and man page

### DIFF
--- a/hydra-gtk/src/interface.c
+++ b/hydra-gtk/src/interface.c
@@ -259,6 +259,7 @@ GtkWidget *create_wndMain(void) {
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "pop3");
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "pcanywhere");
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "postgres");
+  cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "radmin2");
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "rdp");
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "redis");
   cmbProtocol_items = g_list_append(cmbProtocol_items, (gpointer) "rexec");

--- a/hydra.1
+++ b/hydra.1
@@ -13,26 +13,25 @@ hydra \- a very fast network logon cracker which support many different services
 Hydra is a parallelized login cracker which supports numerous protocols
 to attack. New modules are easy to add, beside that, it is flexible and
 very fast.
-
+.LP
 This tool gives researchers and security consultants the possibility to
 show how easy it would be to gain unauthorized access from remote to a
 system.
-
+.TP
 Currently this tool supports:
- adam6500 afp asterisk cisco cisco-enable cvs firebird ftp ftps
- http[s]-{head|get|post} http[s]-{get|post}-form http-proxy
- http-proxy-urlenum icq imap[s] irc ldap2[s]
- ldap3[-{cram|digest}md5][s] mssql mysql(v4) mysql5 ncp nntp
- oracle oracle-listener oracle-sid pcanywhere pcnfs pop3[s]
- postgres rdp redis rexec rlogin rpcap rsh rtsp s7-300 sapr3 sip
- smb smtp[s] smtp-enum snmp socks5 ssh sshkey svn teamspeak telnet[s]
- vmauthd vnc xmpp
-
- For most protocols SSL is supported (e.g. https-get, ftp-ssl, etc.).
- If not all necessary libraries are found during compile time, your
- available services will be less.
- Type "hydra" to see what is available.
-
+adam6500 afp asterisk cisco cisco-enable cvs firebird ftp ftps
+http[s]-{head|get|post} http[s]-{get|post}-form http-proxy
+http-proxy-urlenum icq imap[s] irc ldap2[s]
+ldap3[-{cram|digest}md5][s] mssql mysql(v4) mysql5 ncp nntp
+oracle oracle-listener oracle-sid pcanywhere pcnfs pop3[s]
+postgres rdp radmin2 redis rexec rlogin rpcap rsh rtsp s7-300 sapr3 sip
+smb smtp[s] smtp-enum snmp socks5 ssh sshkey svn teamspeak telnet[s]
+vmauthd vnc xmpp
+.LP
+For most protocols SSL is supported (e.g. https-get, ftp-ssl, etc.).
+If not all necessary libraries are found during compile time, your
+available services will be less.
+Type "hydra" to see what is available.
 .SH Options
 .TP
 .B target
@@ -141,7 +140,6 @@ Show summary of options.
 The programs are documented fully by van Hauser <vh@thc.org>
 .SH AUTHOR
 hydra was written by van Hauser / THC <vh@thc.org>
-
 .PP
 This manual page was written by Daniel Echeverry <epsilon77@gmail.com>,
 for the Debian project (and may be used by others).

--- a/xhydra.1
+++ b/xhydra.1
@@ -7,17 +7,11 @@ Execute xhydra in a terminal to start the application.
 Hydra is a parallelized login cracker which supports numerous protocols
 to attack. New modules are easy to add, beside that, it is flexible and
 very fast.
-
-This tool gives researchers and security consultants the possibility to
-show how easy it would be to gain unauthorized access from remote to a
-system.
-
-Currently this tool supports:
- AFP, Cisco AAA, Cisco auth, Cisco enable, CVS, Firebird, FTP, HTTP-FORM-GET,
- HTTP-FORM-POST, HTTP-GET, HTTP-HEAD, HTTP-PROXY, HTTPS-FORM-GET, HTTPS-FORM-POST,
- HTTPS-GET, HTTPS-HEAD, ICQ, IMAP, IRC, LDAP, MS-SQL, MYSQL, NCP, NNTP, PCNFS, POP3,
- POSTGRES, RDP, REXEC, SAP/R3, SMB, SMTP, SNMP, SOCKS5, SSH(v1 and v2),
- Subversion, Teamspeak (TS2), TELNET, VMware-Auth, VNC and XMPP.
+.LP
+.B xhydra
+is the graphical fronend for the
+.BR hydra (1)
+tool.
 .SH SEE ALSO
 .BR hydra (1),
 .BR pw-inspector (1).


### PR DESCRIPTION
The two commits add radmin2 to both the xhydra selection and the hydra man page.  I've also dropped the listing of modules from the xhydra man page to reduce the duplication and made a few minor markup changes.

Thanks for always being open to minor changes (and improving the spelling even more after the last PR)!