### PR TITLE
Don't add extra slash to url if exist

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -3541,11 +3541,11 @@ int main(int argc, char *argv[]) {
 
   if (hydra_brains.targets == 1) {
     if (index(hydra_targets[0]->target, ':') == NULL)
-      printf("[DATA] attacking %s%s://%s:%d/%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_targets[0]->target, port, hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
+      printf("[DATA] attacking %s%s://%s:%d%s%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_targets[0]->target, port, strstr(hydra_options.miscptr, "/") == hydra_options.miscptr ? "" : "/", hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
     else
-      printf("[DATA] attacking %s%s://[%s]:%d/%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_targets[0]->target, port, hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
+      printf("[DATA] attacking %s%s://[%s]:%d%s%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_targets[0]->target, port, strstr(hydra_options.miscptr, "/") == hydra_options.miscptr ? "" : "/", hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
   } else
-    printf("[DATA] attacking %s%s://(%d targets):%d/%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_brains.targets, port, hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
+    printf("[DATA] attacking %s%s://(%d targets):%d%s%s\n", hydra_options.service, hydra_options.ssl == 1 ? "s" : "", hydra_brains.targets, port, strstr(hydra_options.miscptr, "/") == hydra_options.miscptr ? "" : "/", hydra_options.miscptr != NULL ? hydra_options.miscptr : "");
    //service %s on port %d%s\n", hydra_options.service, port, hydra_options.ssl == 1 ? " with SSL" : "");
 //  if (hydra_options.miscptr != NULL && hydra_options.miscptr[0] != 0)
 //    printf("[DATA] with additional data %s\n", hydra_options.miscptr);


### PR DESCRIPTION
This PR removes an extra `/` which appears in the current hydra's output like this:
```
[DATA] attacking http-get://foo.com:80//bar/
```
And change it to be like this:
```
[DATA] attacking http-get://foo.com:80/bar/
```

The `hydra_options.miscptr` parameter will be checked if it starts with a slash then no need to add another one. If you would like to fix the issue in another way please let me know so I can fix it in an appropriate way.

The command used during testing:
```
hydra -l user -P mylist http-get://foo.com/bar/
```