### PR TITLE
Optionally add request headers to http-get

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -50,6 +50,7 @@ Added fail or success condition, getting cookies, and allow 5 redirections by da
 */
 
 #include "hydra-mod.h"
+#include "hydra-http.h"
 
 /*	HTTP Header Types	*/
 #define HEADER_TYPE_USERHEADER                  'h'
@@ -61,12 +62,12 @@ extern char *HYDRA_EXIT;
 char *buf;
 char *cond;
 
-typedef struct header_node {
+struct header_node {
   char *header;
   char *value;
   char type;
   struct header_node *next;
-} t_header_node, *ptr_header_node;
+};
 
 typedef struct cookie_node {
   char *name;
@@ -81,8 +82,6 @@ int32_t auth_flag = 0;
 
 char cookie[4096] = "", cmiscptr[1024];
 
-extern char *webtarget;
-extern char *slash;
 int32_t webport, freemischttpform = 0;
 char bufferurl[6096 + 24], cookieurl[6096 + 24] = "", userheader[6096 + 24] = "", *url, *variables, *optional1;
 

--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -49,14 +49,7 @@ Added fail or success condition, getting cookies, and allow 5 redirections by da
 
 */
 
-#include "hydra-mod.h"
 #include "hydra-http.h"
-
-/*	HTTP Header Types	*/
-#define HEADER_TYPE_USERHEADER                  'h'
-#define HEADER_TYPE_USERHEADER_REPL             'H'
-#define HEADER_TYPE_DEFAULT                     'D'
-#define HEADER_TYPE_DEFAULT_REPL                'd'
 
 extern char *HYDRA_EXIT;
 char *buf;

--- a/hydra-http.c
+++ b/hydra-http.c
@@ -267,7 +267,7 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_HTTP, mysslport = PORT_HTTP_SSL;
   char *ptr, *ptr2;
-  ptr_header_node ptr_head;
+  ptr_header_node ptr_head = NULL;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
@@ -310,7 +310,8 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
     *ptr++ = 0;
   optional1 = ptr;
 
-  ptr_head = parse_options(optional1);
+  if (!parse_options(optional1, &ptr_head))
+    run = 4;
 
   while (1) {
     next_run = 0;

--- a/hydra-http.c
+++ b/hydra-http.c
@@ -1,4 +1,5 @@
 #include "hydra-mod.h"
+#include "hydra-http.h"
 #include "sasl.h"
 
 extern char *HYDRA_EXIT;
@@ -244,6 +245,7 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_HTTP, mysslport = PORT_HTTP_SSL;
   char *ptr, *ptr2;
+  ptr_header_node ptr_head;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
@@ -277,6 +279,16 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
     webport = myport;
   else
     webport = mysslport;
+
+  /* Advance to options string */
+  ptr = miscptr;
+  while (*ptr != 0 && (*ptr != ':' || *(ptr - 1) == '\\'))
+    ptr++;
+  if (*ptr != 0)
+    *ptr++ = 0;
+  optional1 = ptr;
+
+  ptr_head = parse_options(optional1);
 
   while (1) {
     next_run = 0;

--- a/hydra-http.h
+++ b/hydra-http.h
@@ -1,0 +1,11 @@
+#ifndef _HYDRA_HTTP_H
+#define _HYDRA_HTTP_H
+
+typedef struct header_node t_header_node, *ptr_header_node;
+
+extern char *webtarget;
+extern char *slash;
+extern char *optional1;
+
+extern ptr_header_node parse_options(char *miscptr);
+#endif

--- a/hydra-http.h
+++ b/hydra-http.h
@@ -1,6 +1,14 @@
 #ifndef _HYDRA_HTTP_H
 #define _HYDRA_HTTP_H
 
+#include "hydra-mod.h"
+
+/*	HTTP Header Types	*/
+#define HEADER_TYPE_USERHEADER                  'h'
+#define HEADER_TYPE_USERHEADER_REPL             'H'
+#define HEADER_TYPE_DEFAULT                     'D'
+#define HEADER_TYPE_DEFAULT_REPL                'd'
+
 typedef struct header_node t_header_node, *ptr_header_node;
 
 extern char *webtarget;
@@ -8,4 +16,6 @@ extern char *slash;
 extern char *optional1;
 
 extern ptr_header_node parse_options(char *miscptr);
+extern int32_t add_header(ptr_header_node * ptr_head, char *header, char *value, char type);
+extern char *stringify_headers(ptr_header_node *ptr_head);
 #endif

--- a/hydra-http.h
+++ b/hydra-http.h
@@ -15,7 +15,7 @@ extern char *webtarget;
 extern char *slash;
 extern char *optional1;
 
-extern ptr_header_node parse_options(char *miscptr);
+extern int32_t parse_options(char *miscptr, ptr_header_node * ptr_head);
 extern int32_t add_header(ptr_header_node * ptr_head, char *header, char *value, char type);
 extern char *stringify_headers(ptr_header_node *ptr_head);
 #endif


### PR DESCRIPTION
This adds support for optionally adding headers to `http-get` and `http-post` via `(h|H)=My-Hdr\: foo`. I believe this should close #321 and #100. Please let me know if I've made any mistakes or if there's anything you'd like to see changed. Thanks!