### PR TITLE
Fix compilation error when Mongo and Memcache libraries are absent

### DIFF
--- a/hydra-mongodb.c
+++ b/hydra-mongodb.c
@@ -9,7 +9,7 @@
 #include "hydra-mod.h"
 
 #ifndef LIBMONGODB
-void dummy_mcached() {
+void dummy_mongodb() {
   printf("\n");
 }
 #else


### PR DESCRIPTION
Tiny change, there's a duplicated function name: dummy_mcached.