### PR TITLE
Rebuild JSON report file in first time and append while using -R

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -3560,19 +3560,21 @@ int main(int argc, char *argv[]) {
       perror("[ERROR] Error creating outputfile");
       exit(-1);
     }
-    if (hydra_options.outfile_format == FORMAT_JSONV1 && hydra_options.restore != 1) { // No JSON head while using -R
-      fprintf(hydra_brains.ofp, "{ \"generator\": {\n"
+    if (hydra_options.outfile_format == FORMAT_JSONV1) {
+      if (hydra_options.restore != 1) { // No JSON head while using -R
+        fprintf(hydra_brains.ofp, "{ \"generator\": {\n"
               "\t\"software\": \"%s\", \"version\": \"%s\", \"built\": \"%s\",\n"
               "\t\"server\": \"%s\", \"service\": \"%s\", \"jsonoutputversion\": \"1.00\",\n"
               "\t\"commandline\": \"%s",
             PROGRAM, VERSION, hydra_build_time(),
             hydra_options.server == NULL ? hydra_options.infile_ptr : hydra_options.server, hydra_options.service, prg);
-      for (i = 1; i < argc; i++) {
-        char *t = hydra_string_replace(argv[i],"\"","\\\"");
-        fprintf(hydra_brains.ofp, " %s", t);
-        free(t);
+        for (i = 1; i < argc; i++) {
+          char *t = hydra_string_replace(argv[i],"\"","\\\"");
+          fprintf(hydra_brains.ofp, " %s", t);
+          free(t);
+        }
+        fprintf(hydra_brains.ofp, "\"\n\t},\n\"results\": [");
       }
-      fprintf(hydra_brains.ofp, "\"\n\t},\n\"results\": [");
     } else { // else default is plain text aka == 0
       fprintf(hydra_brains.ofp, "# %s %s run at %s on %s %s (%s", PROGRAM, VERSION, hydra_build_time(),
             hydra_options.server == NULL ? hydra_options.infile_ptr : hydra_options.server, hydra_options.service, prg);

--- a/hydra.c
+++ b/hydra.c
@@ -3552,11 +3552,15 @@ int main(int argc, char *argv[]) {
 //    printf("[DATA] with additional data %s\n", hydra_options.miscptr);
 
   if (hydra_options.outfile_ptr != NULL) {
-    if ((hydra_brains.ofp = fopen(hydra_options.outfile_ptr, "a+")) == NULL) {
+    char outfile_open_type[] = "a+"; //Default open in a+ mode
+    if (hydra_options.outfile_format == FORMAT_JSONV1 && hydra_options.restore != 1) {
+      outfile_open_type[0] = 'w'; //Creat new outfile, if using JSON output and not using -R. The open mode should be "w+".
+    }
+    if ((hydra_brains.ofp = fopen(hydra_options.outfile_ptr, outfile_open_type)) == NULL) {
       perror("[ERROR] Error creating outputfile");
       exit(-1);
     }
-    if (hydra_options.outfile_format == FORMAT_JSONV1) {
+    if (hydra_options.outfile_format == FORMAT_JSONV1 && hydra_options.restore != 1) { // No JSON head while using -R
       fprintf(hydra_brains.ofp, "{ \"generator\": {\n"
               "\t\"software\": \"%s\", \"version\": \"%s\", \"built\": \"%s\",\n"
               "\t\"server\": \"%s\", \"service\": \"%s\", \"jsonoutputversion\": \"1.00\",\n"


### PR DESCRIPTION
Hi,
My last PR did ignore the -R situation. This time I fixed this problem.
Now the JSON output file will be rebuilt when the session is first started, and in the -R it append.
I have tested that the JSON output is correct whether it's new or restored.

PS:
I try to make this clean, so I add a new "outfile_open_type" to avoid repeated "fopen".

Thanks & Regards,
Galaxy