### PR TITLE
add authentication type switching option

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -50,6 +50,7 @@ Added fail or success condition, getting cookies, and allow 5 redirections by da
 */
 
 #include "hydra-http.h"
+#include "sasl.h"
 
 extern char *HYDRA_EXIT;
 char *buf;
@@ -397,6 +398,36 @@ int32_t parse_options(char *miscptr, ptr_header_node *ptr_head) {
    */
   while (*miscptr != 0) {
     switch (miscptr[0]) {
+    case 'a':
+    case 'A':
+      // grab the value
+      ptr = miscptr + 2;
+
+      // and make it lowercase
+      while (*ptr != 0 && *ptr != ':') {
+        *ptr = tolower(*ptr);
+        ptr++;
+      }
+
+      if (*ptr != 0) {
+        *ptr = 0;
+        ptr += 1;
+      }
+
+      // AUTH_BASIC is a default value of http_auth_type variable defined in hydra-http.c, it could be skipped here
+      if (strcmp(miscptr + 2, "basic") == 0)
+        http_auth_type = AUTH_BASIC;
+      else if (strcmp(miscptr + 2, "ntlm") == 0)
+        http_auth_type = AUTH_NTLM;
+      else if (strcmp(miscptr + 2, "digest") == 0)
+        http_auth_type = AUTH_DIGESTMD5;
+      else {
+        hydra_report(stderr, "[ERROR] Incorrect authentication type is provided.\n");
+        return 0;
+      }
+
+      miscptr = ptr;
+      break;
     case 'c':                  // fall through
     case 'C':
       ptr = miscptr + 2;

--- a/hydra-http.h
+++ b/hydra-http.h
@@ -14,6 +14,7 @@ typedef struct header_node t_header_node, *ptr_header_node;
 extern char *webtarget;
 extern char *slash;
 extern char *optional1;
+extern int32_t http_auth_type;
 
 extern int32_t parse_options(char *miscptr, ptr_header_node * ptr_head);
 extern int32_t add_header(ptr_header_node * ptr_head, char *header, char *value, char type);


### PR DESCRIPTION
If a server responds with multiple authentication type headers
```
WWW-Authenticate: NTLM ...
WWW-Authenticate: Negotiate
WWW-Authenticate: Basic realm="..."
```
then there is a need for an option for switching authentication type to test credentials using the certain type instead of Basic