### PR TITLE
Worked around APR_PATH_MAX errors on some Linuxes when SVN is enabled.

### DIFF
--- a/configure
+++ b/configure
@@ -557,6 +557,10 @@ for i in $INCDIRS ; do
         fi
     fi  
 done
+SYS_PARAM=""
+if [ -f "$SDK_PATH/usr/include/sys/param.h" ]; then
+  SYS_PARAM=-DHAVE_SYS_PARAM_H
+fi
 if [ "X" != "X$DEBUG" ]; then
    echo DEBUG: SVN_PATH=$SVN_PATH/libsvn_client-1
    echo DEBUG: APR_PATH=$APR_PATH/libapr
@@ -1501,7 +1505,7 @@ else
 fi
 
 if [ "X" != "X$DEBUG" ]; then
-   echo DEBUG: XDEFINES=$XDEFINES $MATH
+   echo DEBUG: XDEFINES=$XDEFINES $MATH $SYS_PARAM
    echo DEBUG: XLIBS=$XLIBS
    echo DEBUG: XLIBPATHS=$XLIBPATHS
    echo DEBUG: XIPATHS=$XIPATHS
@@ -1519,7 +1523,7 @@ if [ "X" != "X$FHS" ]; then
   echo "MANDIR = /share/man/man1" >> Makefile.in
   echo "DATADIR = /share/hydra" >> Makefile.in
 fi
-echo "XDEFINES=$XDEFINES $MATH" >> Makefile.in
+echo "XDEFINES=$XDEFINES $MATH $SYS_PARAM" >> Makefile.in
 echo "XLIBS=$XLIBS" >> Makefile.in
 echo "XLIBPATHS=$XLIBPATHS" >> Makefile.in
 echo "XIPATHS=$XIPATHS" >> Makefile.in

--- a/hydra-svn.c
+++ b/hydra-svn.c
@@ -6,6 +6,10 @@
 /* needed on openSUSE */
 #define _GNU_SOURCE
 
+#if !defined PATH_MAX && defined HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 #include <svn_client.h>
 #include <svn_cmdline.h>
 #include <svn_pools.h>


### PR DESCRIPTION
On Gentoo Linux (and possibly others?) with Subversion 1.12.0,
compilation of hydra-svn.c fails with:

In file included from /usr/include/subversion-1/svn_client.h:34,
                 from hydra-svn.c:9:
/usr/include/apr-1/apr.h:632:2: error: #error no decision has been made on APR_PATH_MAX for your platform
 #error no decision has been made on APR_PATH_MAX for your platform
  ^~~~~

This happens when PATH_MAX is not defined.

PATH_MAX is defined by /usr/include/linux/limits.h, but rather than
include'ing that directly and possibly breaking other platforms,
include sys/param.h (which will include linux/limits.h indirectly)
iff PATH_MAX is not defined and sys/param.h exists.

I based the approach on how math.h is handled.