### PR TITLE
Fix dump with folder

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -1046,15 +1046,17 @@ void fill_mem(char *ptr, FILE * fd, int32_t colonmode) {
   char tmp[MAXBUF + 4] = "", *ptr2;
   uint32_t len;
   int32_t only_one_empty_line = 0;
+
+int read_flag = 0;
 #ifdef HAVE_ZLIB
   gzFile fp = gzdopen(fileno(fd), "r");
 
-  while (!gzeof(fp)) {
+  while (!gzeof(fp) && !read_flag) {
     if (gzgets(fp, tmp, MAXLINESIZE) != NULL) {
 #else
   FILE *fp = fd;
 
-  while (!feof(fp)) {
+  while (!feof(fp) && !read_flag) {
     if (fgets(tmp, MAXLINESIZE, fp) != NULL) {
 #endif
       if (tmp[0] != 0) {
@@ -1082,6 +1084,8 @@ void fill_mem(char *ptr, FILE * fd, int32_t colonmode) {
           ptr++;
         }
       }
+    } else {
+      read_flag = 1;
     }
   }
 #ifdef HAVE_ZLIB


### PR DESCRIPTION
Hi, I know that it's looks like a crunch, but when user send `-C /tmp` hydra start endless loop in hydra.c:L1054-L1090. Add flag which trigered if nothing readed.

![Screen Shot 2019-08-30 at 3 00 33 PM](https://user-images.githubusercontent.com/7644109/64019866-ec070180-cb38-11e9-8148-e8eb78b94ffb.png)

And good case 

![Screen Shot 2019-08-30 at 3 00 53 PM](https://user-images.githubusercontent.com/7644109/64019879-f6c19680-cb38-11e9-9639-c07e5d3e9e40.png)


Close https://github.com/vanhauser-thc/thc-hydra/issues/316