### PR TITLE
hydra-vnc: Use buf2 instead of buf in hydra_report

### DIFF
--- a/hydra-vnc.c
+++ b/hydra-vnc.c
@@ -75,7 +75,7 @@ int32_t start_vnc(int32_t s, char *ip, int32_t port, unsigned char options, char
   //supported security type
   switch (buf2[3]) {
   case 0x0:
-    hydra_report(stderr, "[ERROR] VNC server told us to quit %c\n", buf[3]);
+    hydra_report(stderr, "[ERROR] VNC server told us to quit %c\n", buf2[3]);
     hydra_child_exit(0);
     break;
   case 0x1:


### PR DESCRIPTION
A compiler warning told me that buf was used uninitialised here and it
turned out that instead of buf2, buf was being used. It makes a lot more
sense to report buf2 and that happens to fix the warning as well.