### PR TITLE
Fix -fno-common linker errors

### DIFF
--- a/hydra-asterisk.c
+++ b/hydra-asterisk.c
@@ -9,11 +9,11 @@
 
 extern char *HYDRA_EXIT;
 
-char *buf;
-
 int32_t start_asterisk(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "\"\"";
   char *login, *pass, buffer[1024];
+  char *buf;
+
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -65,6 +65,7 @@ int32_t start_asterisk(int32_t s, char *ip, int32_t port, unsigned char options,
 void service_asterisk(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname) {
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_ASTERISK, mysslport = PORT_ASTERISK_SSL;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-cisco-enable.c
+++ b/hydra-cisco-enable.c
@@ -1,11 +1,11 @@
 #include "hydra-mod.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 int32_t start_cisco_enable(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
   char *pass, buffer[300];
+  char *buf;
 
   if (strlen(pass = hydra_get_next_password()) == 0)
     pass = empty;
@@ -63,6 +63,7 @@ void service_cisco_enable(char *ip, int32_t sp, unsigned char options, char *mis
   int32_t myport = PORT_TELNET, mysslport = PORT_TELNET_SSL;
   char buffer[300];
   char *login;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-cisco.c
+++ b/hydra-cisco.c
@@ -5,11 +5,11 @@
 #endif
 
 extern char *HYDRA_EXIT;
-char *buf = NULL;
 
 int32_t start_cisco(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
   char *pass, buffer[300];
+  char *buf = NULL;
 
   if (strlen(pass = hydra_get_next_password()) == 0)
     pass = empty;

--- a/hydra-cvs.c
+++ b/hydra-cvs.c
@@ -3,7 +3,6 @@
 extern int32_t hydra_data_ready_timed(int32_t socket, long sec, long usec);
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 int32_t start_cvs(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
@@ -37,6 +36,7 @@ int32_t start_cvs(int32_t s, char *ip, int32_t port, unsigned char options, char
     0, 121, 117, 104, 101, 100, 69, 73, 99, 63, 94, 93, 39, 37, 61, 48,
     58, 113, 32, 90, 44, 98, 60, 51, 33, 97, 62
   };
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;

--- a/hydra-ftp.c
+++ b/hydra-ftp.c
@@ -1,11 +1,11 @@
 #include "hydra-mod.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 int32_t start_ftp(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "\"\"";
   char *login, *pass, buffer[510];
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -77,6 +77,7 @@ int32_t start_ftp(int32_t s, char *ip, int32_t port, unsigned char options, char
 void service_ftp_core(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname, int32_t tls) {
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_FTP, mysslport = PORT_FTP_SSL;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-gtk/src/callbacks.c
+++ b/hydra-gtk/src/callbacks.c
@@ -66,7 +66,7 @@ int hydra_get_options(char *options[]) {
   gchar *tmp;
   GString *a;
 
-  options[0] = HYDRA_BIN;
+  options[0] = hydra_bin;
 
   /* get the port */
   widget = lookup_widget(GTK_WIDGET(wndMain), "spnPort");
@@ -599,7 +599,7 @@ int *popen_re_unbuffered(char *command) {
 
     (void) hydra_get_options(options);
 
-    execv(HYDRA_BIN, options);
+    execv(hydra_bin, options);
 
     g_warning("%s %i: popen_rw_unbuffered: execv() returned", __FILE__, __LINE__);
 

--- a/hydra-gtk/src/main.c
+++ b/hydra-gtk/src/main.c
@@ -17,12 +17,12 @@
 char *hydra_path1 = "./hydra";
 char *hydra_path2 = "/usr/local/bin/hydra";
 char *hydra_path3 = "/usr/bin/hydra";
-
+char *hydra_bin;
+GtkWidget *wndMain;
+guint message_id;
 
 int main(int argc, char *argv[]) {
-  extern GtkWidget *wndMain;
   int i;
-  extern guint message_id;
   GtkWidget *output;
   GtkTextBuffer *outputbuf;
 
@@ -35,22 +35,22 @@ int main(int argc, char *argv[]) {
   message_id = 0;
 
   /* locate the hydra binary */
-  HYDRA_BIN = NULL;
+  hydra_bin = NULL;
   for (i = 0; i < argc - 1; i++) {
     if (!strcmp(argv[i], "--hydra-path")) {
-      HYDRA_BIN = argv[i + 1];
+      hydra_bin = argv[i + 1];
       break;
     }
   }
 
-  if ((HYDRA_BIN != NULL) && (g_file_test(HYDRA_BIN, G_FILE_TEST_IS_EXECUTABLE))) {
+  if ((hydra_bin != NULL) && (g_file_test(hydra_bin, G_FILE_TEST_IS_EXECUTABLE))) {
     /* just for obfuscation *g* */
   } else if (g_file_test(hydra_path1, G_FILE_TEST_IS_EXECUTABLE)) {
-    HYDRA_BIN = hydra_path1;
+    hydra_bin = hydra_path1;
   } else if (g_file_test(hydra_path2, G_FILE_TEST_IS_EXECUTABLE)) {
-    HYDRA_BIN = hydra_path2;
+    hydra_bin = hydra_path2;
   } else if (g_file_test(hydra_path3, G_FILE_TEST_IS_EXECUTABLE)) {
-    HYDRA_BIN = hydra_path3;
+    hydra_bin = hydra_path3;
   } else {
     g_error("Please tell me where hydra is, use --hydra-path\n");
     return -1;

--- a/hydra-gtk/src/support.h
+++ b/hydra-gtk/src/support.h
@@ -40,6 +40,6 @@ GdkPixbuf *create_pixbuf(const gchar * filename);
 void glade_set_atk_action_description(AtkAction * action, const gchar * action_name, const gchar * description);
 
 
-GtkWidget *wndMain;
-char *HYDRA_BIN;
-guint message_id;
+extern GtkWidget *wndMain;
+extern char *hydra_bin;
+extern guint message_id;

--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -53,7 +53,6 @@ Added fail or success condition, getting cookies, and allow 5 redirections by da
 #include "sasl.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 char *cond;
 extern int32_t http_auth_mechanism;
 
@@ -579,6 +578,7 @@ return -1 if no response from server
 */
 int32_t analyze_server_response(int32_t s) {
   int32_t runs = 0;
+  char *buf;
 
   redirected_flag = 0;
   auth_flag = 0;

--- a/hydra-http-proxy-urlenum.c
+++ b/hydra-http-proxy-urlenum.c
@@ -2,7 +2,6 @@
 #include "sasl.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 static int32_t http_proxy_auth_mechanism = AUTH_ERROR;
 
 int32_t start_http_proxy_urlenum(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp, char *hostname) {
@@ -12,6 +11,7 @@ int32_t start_http_proxy_urlenum(int32_t s, char *ip, int32_t port, unsigned cha
   char *header = "";            /* XXX TODO */
   char *ptr;
   int32_t auth = 0;
+  char *buf;
 
   login = hydra_get_next_login();
   if (login == NULL || strlen(login) == 0 || strstr(login, "://") == NULL) {

--- a/hydra-http.c
+++ b/hydra-http.c
@@ -12,7 +12,7 @@ char *http_buf = NULL;
 static char end_condition[END_CONDITION_MAX_LEN];
 int end_condition_type=-1;
 
-int32_t webport, freemischttp = 0;
+int32_t freemischttp = 0;
 int32_t http_auth_mechanism = AUTH_UNASSIGNED;
 
 int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp, char *type, ptr_header_node ptr_head) {
@@ -22,6 +22,7 @@ int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, cha
   char *ptr, *fooptr;
   int32_t complete_line = 0, buffer_size;
   char tmpreplybuf[1024] = "", *tmpreplybufptr;
+  int32_t webport;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -291,6 +292,7 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   int32_t myport = PORT_HTTP, mysslport = PORT_HTTP_SSL;
   char *ptr, *ptr2;
   ptr_header_node ptr_head = NULL;
+  int32_t webport;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-imap.c
+++ b/hydra-imap.c
@@ -2,7 +2,6 @@
 #include "sasl.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 int32_t counter;
 
 int32_t imap_auth_mechanism = AUTH_CLEAR;
@@ -42,6 +41,7 @@ char *imap_read_server_capacity(int32_t sock) {
 int32_t start_imap(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
   char *login, *pass, buffer[500], buffer2[500], *fooptr;
+  char *buf = NULL;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -357,6 +357,7 @@ void service_imap(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_IMAP, mysslport = PORT_IMAP_SSL, disable_tls = 1;
   char *buffer1 = "1 CAPABILITY\r\n";
+  char *buf = NULL;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-ldap.c
+++ b/hydra-ldap.c
@@ -3,8 +3,6 @@
 
 extern char *HYDRA_EXIT;
 
-unsigned char *buf;
-int32_t counter;
 int32_t tls_required = 0;
 
 int32_t start_ldap(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp, char *hostname, char version, int32_t auth_method) {
@@ -13,6 +11,8 @@ int32_t start_ldap(int32_t s, char *ip, int32_t port, unsigned char options, cha
   unsigned char buffer[512];
   int32_t length = 0;
   int32_t ldap_auth_mechanism = auth_method;
+  unsigned char *buf;
+  int32_t counter;
 
   /*
      The LDAP "simple" method has three modes of operation:
@@ -354,6 +354,8 @@ int32_t start_ldap(int32_t s, char *ip, int32_t port, unsigned char options, cha
 void service_ldap(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname, char version, int32_t auth_method) {
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_LDAP, mysslport = PORT_LDAP_SSL;
+  unsigned char *buf;
+  int32_t counter;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-mod.c
+++ b/hydra-mod.c
@@ -48,6 +48,19 @@ char ipstring[64];
 uint32_t colored_output = 1;
 char quiet = 0;
 int32_t old_ssl = 0;
+int32_t debug;
+char *proxy_authentication[MAX_PROXY_COUNT];
+int32_t proxy_count;
+char proxy_string_ip[MAX_PROXY_COUNT][36];
+char proxy_string_type[MAX_PROXY_COUNT][10];
+int32_t proxy_string_port[MAX_PROXY_COUNT];
+int32_t selected_proxy;
+int32_t verbose;
+int32_t waittime;
+int32_t use_proxy;
+int32_t port;
+char *cmdlinetarget;
+int32_t found;
 
 #ifdef LIBOPENSSL
 SSL *ssl = NULL;

--- a/hydra-mod.h
+++ b/hydra-mod.h
@@ -49,23 +49,23 @@ extern int32_t hydra_memsearch(char *haystack, int32_t hlen, char *needle, int32
 extern char *hydra_strrep(char *string, char *oldpiece, char *newpiece);
 
 #ifdef HAVE_PCRE
-int32_t hydra_string_match(char *str, const char *regex);
+extern int32_t hydra_string_match(char *str, const char *regex);
 #endif
-char *hydra_string_replace(const char *string, const char *substr, const char *replacement);
+extern char *hydra_string_replace(const char *string, const char *substr, const char *replacement);
 
-int32_t debug;
-int32_t verbose;
-int32_t waittime;
-int32_t port;
-int32_t found;
-int32_t proxy_count;
-int32_t use_proxy;
-int32_t selected_proxy;
-char proxy_string_ip[MAX_PROXY_COUNT][36];
-int32_t proxy_string_port[MAX_PROXY_COUNT];
-char proxy_string_type[MAX_PROXY_COUNT][10];
-char *proxy_authentication[MAX_PROXY_COUNT];
-char *cmdlinetarget;
+extern int32_t debug;
+extern int32_t verbose;
+extern int32_t waittime;
+extern int32_t port;
+extern int32_t found;
+extern int32_t proxy_count;
+extern int32_t use_proxy;
+extern int32_t selected_proxy;
+extern char proxy_string_ip[MAX_PROXY_COUNT][36];
+extern int32_t proxy_string_port[MAX_PROXY_COUNT];
+extern char proxy_string_type[MAX_PROXY_COUNT][10];
+extern char *proxy_authentication[MAX_PROXY_COUNT];
+extern char *cmdlinetarget;
 
 typedef int32_t BOOL;
 

--- a/hydra-mongodb.c
+++ b/hydra-mongodb.c
@@ -17,7 +17,6 @@ void dummy_mongodb() {
 extern int32_t hydra_data_ready_timed(int32_t socket, long sec, long usec);
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 #define DEFAULT_DB "admin"
 
@@ -31,6 +30,7 @@ int is_error_msg(char *msg) {
 }
 
 int require_auth(int32_t sock) {
+  char *buf;
   unsigned char m_hdr[] =
     "\x3f\x00\x00\x00"  //messageLength (63)
     "\x00\x00\x00\x41"  //requestID

--- a/hydra-mssql.c
+++ b/hydra-mssql.c
@@ -3,7 +3,6 @@
 #define MSLEN 30
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 unsigned char p_hdr[] =
   "\x02\x00\x02\x00\x00\x00\x02\x00\x00\x00" "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" "\x00\x00\x00\x00\x00\x00\x00\x00\x00";
@@ -52,6 +51,7 @@ int32_t start_mssql(int32_t s, char *ip, int32_t port, unsigned char options, ch
   char ms_pass[MSLEN + 1];
   unsigned char len_login, len_pass;
   int32_t ret = -1;
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;

--- a/hydra-nntp.c
+++ b/hydra-nntp.c
@@ -13,7 +13,6 @@ RFC 4643: Network News Transfer Protocol (NNTP) Extension for Authentication
 int32_t nntp_auth_mechanism = AUTH_CLEAR;
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 char *nntp_read_server_capacity(int32_t sock) {
   char *ptr = NULL;
@@ -51,6 +50,7 @@ int32_t start_nntp(int32_t s, char *ip, int32_t port, unsigned char options, cha
   char *empty = "\"\"";
   char *login, *pass, buffer[500], buffer2[500], *fooptr;
   int32_t i = 1;
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -270,6 +270,7 @@ void service_nntp(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   int32_t i = 0, run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_NNTP, mysslport = PORT_NNTP_SSL, disable_tls = 0;
   char *buffer1 = "CAPABILITIES\r\n";
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-oracle-listener.c
+++ b/hydra-oracle-listener.c
@@ -22,8 +22,6 @@ void dummy_oracle_listener() {
 #define HASHSIZE 17
 
 extern char *HYDRA_EXIT;
-char *buf;
-unsigned char *hash;
 int32_t sid_mechanism = AUTH_PLAIN;
 
 int32_t initial_permutation(unsigned char **result, char *p_str, int32_t *sz) {
@@ -143,6 +141,7 @@ int32_t ora_hash_password(char *pass) {
   unsigned char *desresult;
   unsigned char *result;
   char buff[strlen(pass) + 5];
+  unsigned char *hash;
 
   memset(buff, 0, sizeof(buff));
 
@@ -192,6 +191,8 @@ int32_t start_oracle_listener(int32_t s, char *ip, int32_t port, unsigned char o
   char connect_string[200];
   char buffer2[260];
   int32_t siz = 0;
+  char *buf;
+  unsigned char *hash;
 
   memset(connect_string, 0, sizeof(connect_string));
   memset(buffer2, 0, sizeof(buffer2));

--- a/hydra-oracle-sid.c
+++ b/hydra-oracle-sid.c
@@ -19,7 +19,6 @@ void dummy_oracle_sid() {
 #define HASHSIZE 16
 
 extern char *HYDRA_EXIT;
-char *buf;
 unsigned char *hash;
 
 
@@ -40,6 +39,7 @@ int32_t start_oracle_sid(int32_t s, char *ip, int32_t port, unsigned char option
   char connect_string[200];
   char buffer2[260];
   int32_t siz = 0;
+  char *buf;
 
   memset(connect_string, 0, sizeof(connect_string));
   memset(buffer2, 0, sizeof(buffer2));

--- a/hydra-pcnfs.c
+++ b/hydra-pcnfs.c
@@ -3,7 +3,6 @@
 /* pcnfs stuff copied from prout.c */
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 #define LEN_HDR_RPC	24
 #define LEN_AUTH_UNIX   72+12
@@ -37,6 +36,7 @@ int32_t start_pcnfs(int32_t s, char *ip, int32_t port, unsigned char options, ch
   char *empty = "";
   char *login, *pass, buffer[LEN_HDR_RPC + LEN_AUTH_UNIX + LEN_HDR_PCN_AUTH];
   char *ptr, *pkt = buffer;
+  char *buf;
 
   unsigned long *authp;
   struct timeval tv;

--- a/hydra-pop3.c
+++ b/hydra-pop3.c
@@ -13,7 +13,6 @@ typedef struct pool_str {
 } pool;
 
 extern char *HYDRA_EXIT;
-char *buf;
 char apop_challenge[300] = "";
 pool *plist = NULL, *p = NULL;
 
@@ -120,6 +119,7 @@ STLS
 int32_t start_pop3(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "\"\"";
   char *login, *pass, buffer[500], buffer2[500], *fooptr;
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -416,6 +416,7 @@ int32_t start_pop3(int32_t s, char *ip, int32_t port, unsigned char options, cha
 void service_pop3(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname) {
   int32_t run = 1, next_run = 1, sock = -1;
   char *ptr = NULL;
+  char *buf;
 
   //extract data from the pool, ip is the key
   if (plist == NULL)
@@ -520,6 +521,7 @@ int32_t service_pop3_init(char *ip, int32_t sp, unsigned char options, char *mis
   char *capa_str = "CAPA\r\n";
   char *quit_str = "QUIT\r\n";
   pool p;
+  char *buf;
 
   p.pop3_auth_mechanism = AUTH_CLEAR;
   p.disable_tls = 1;

--- a/hydra-redis.c
+++ b/hydra-redis.c
@@ -1,11 +1,11 @@
 #include "hydra-mod.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 int32_t start_redis(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *pass, buffer[510];
   char *empty = "";
+  char *buf;
 
   if (strlen(pass = hydra_get_next_password()) == 0)
     pass = empty;
@@ -134,6 +134,7 @@ int32_t service_redis_init(char *ip, int32_t sp, unsigned char options, char *mi
   int32_t sock = -1;
   int32_t myport = PORT_REDIS, mysslport = PORT_REDIS_SSL;
   char buffer[] = "*1\r\n$4\r\nping\r\n";
+  char *buf;
 
   hydra_register_socket(sp);
   if ((options & OPTION_SSL) == 0) {

--- a/hydra-smtp-enum.c
+++ b/hydra-smtp-enum.c
@@ -14,7 +14,6 @@ passwd will be used as the domain name
 #include "hydra-mod.h"
 
 extern char *HYDRA_EXIT;
-char *buf;
 char *err = NULL;
 int32_t tosent = 0;
 
@@ -27,6 +26,7 @@ int32_t smtp_enum_cmd = VRFY;
 int32_t start_smtp_enum(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
   char *login, *pass, buffer[500];
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -154,6 +154,7 @@ void service_smtp_enum(char *ip, int32_t sp, unsigned char options, char *miscpt
   int32_t run = 1, next_run = 1, sock = -1, i = 0;
   int32_t myport = PORT_SMTP, mysslport = PORT_SMTP_SSL;
   char *buffer = "HELO hydra\r\n";
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-socks5.c
+++ b/hydra-socks5.c
@@ -10,7 +10,6 @@ This module enable bruteforcing for socks5, only following types are supported:
 */
 
 extern char *HYDRA_EXIT;
-unsigned char *buf;
 
 int32_t fail_cnt;
 
@@ -18,6 +17,7 @@ int32_t start_socks5(int32_t s, char *ip, int32_t port, unsigned char options, c
   char *empty = "";
   char *login, *pass, buffer[300];
   int32_t pport, fud = 0;
+  unsigned char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;

--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -2,13 +2,13 @@
 #include <arpa/telnet.h>
 
 extern char *HYDRA_EXIT;
-char *buf;
 int32_t no_line_mode;
 
 int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "";
   char *login, *pass, buffer[300];
   int32_t i = 0;
+  char *buf;
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -99,6 +99,7 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
 void service_telnet(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname) {
   int32_t run = 1, next_run = 1, sock = -1, fck;
   int32_t myport = PORT_TELNET, mysslport = PORT_TELNET_SSL;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-vmauthd.c
+++ b/hydra-vmauthd.c
@@ -8,11 +8,11 @@
 
 extern char *HYDRA_EXIT;
 
-char *buf;
-
 int32_t start_vmauthd(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE * fp) {
   char *empty = "\"\"";
   char *login, *pass, buffer[300];
+  char *buf;
+
 
   if (strlen(login = hydra_get_next_login()) == 0)
     login = empty;
@@ -68,6 +68,7 @@ int32_t start_vmauthd(int32_t s, char *ip, int32_t port, unsigned char options, 
 void service_vmauthd(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname) {
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_VMAUTHD, mysslport = PORT_VMAUTHD_SSL;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)

--- a/hydra-vnc.c
+++ b/hydra-vnc.c
@@ -19,7 +19,6 @@ int32_t vnc_client_version = RFB33;
 int32_t failed_auth = 0;
 
 extern char *HYDRA_EXIT;
-char *buf;
 
 /*
  * Encrypt CHALLENGESIZE bytes in memory using a password.
@@ -48,6 +47,7 @@ int32_t start_vnc(int32_t s, char *ip, int32_t port, unsigned char options, char
   char *empty = "";
   char *pass;
   unsigned char buf2[CHALLENGESIZE + 4];
+  char *buf;
 
   if (strlen(pass = hydra_get_next_password()) == 0)
     pass = empty;
@@ -148,6 +148,7 @@ int32_t start_vnc(int32_t s, char *ip, int32_t port, unsigned char options, char
 void service_vnc(char *ip, int32_t sp, unsigned char options, char *miscptr, FILE * fp, int32_t port, char *hostname) {
   int32_t run = 1, next_run = 1, sock = -1;
   int32_t myport = PORT_VNC, mysslport = PORT_VNC_SSL;
+  char *buf;
 
   hydra_register_socket(sp);
   if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)


### PR DESCRIPTION
GCC 10 will enable -fno-common by default, which causes linker failures in hydra and xhydra. Fix various declarations and definitions of global variables.