### PR TITLE
Consider the /usr/include/firebird/ path for fb

### DIFF
--- a/configure
+++ b/configure
@@ -627,6 +627,9 @@ for i in $INCDIRS ; do
         if [ -f "$i/ibase.h" ]; then
             FIREBIRD_IPATH="$i"
         fi
+        if [ -f "$i/firebird/ibase.h" ]; then
+            FIREBIRD_IPATH="$i/firebird"
+        fi
     fi
 done
 if [ "X" != "X$DEBUG" ]; then


### PR DESCRIPTION
For example on the Fedora 31 the path for the firebird include ibase.h is /usr/include/firebird/ibase.
This patch should also consider the firebird subdirectory inside the regular include directory.