### PR TITLE
html_encode the + character

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -576,6 +576,8 @@ char *html_encode(char *string) {
     ret = hydra_strrep(ret, "#", "%23");
   if (index(ret, '=') != NULL)
     ret = hydra_strrep(ret, "=", "%3D");
+  if (index(ret, '+') != NULL)
+    ret = hydra_strrep(ret, "+", "%2B");
 
   return ret;
 }


### PR DESCRIPTION
Hello.

I tried your awesome tool using emails as `^USER^` in a http `GET` request.
In my wordlist some email addresses contain "+" (for alias).

It seems thc-hydra doesn't url-encode the "+" failing the request, so I added it to the url-encodable character in this PR.
What do you think ? 😄 

Thank you in advance.