### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: c
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-
 language: c
 sudo: required
 dist: trusty
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3