### PR TITLE
http-form: ipv6 fix 

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -1039,7 +1039,7 @@ int32_t start_http_form(int32_t s, char *ip, int32_t port, unsigned char options
       }
 
       if (strrchr(url, ':') == NULL && port != 80) {
-        sprintf(str2, "%s:%d", str2, port);
+        sprintf(str2, "%.2040s:%d", str2, port);
       }
 
       if (verbose)

--- a/hydra.c
+++ b/hydra.c
@@ -610,10 +610,6 @@ void help_bfg() {
 
 void module_usage() {
   int32_t i;
-  if (!hydra_options.service) {
-    printf("The Module %s does not need or support optional parameters\n", hydra_options.service);
-    exit(0);
-  }
 
   printf("\nHelp for module "
          "%s:\n================================================================"


### PR DESCRIPTION
Hello,

I noticed that when using the http-form module with an ipv6 address that it was failing to work. After investigation, it appears the `Host` header was not correctly formatted, resulting in the following:

![Screenshot_20201111_142823](https://user-images.githubusercontent.com/527411/98960664-9c71e300-24fc-11eb-8977-6cea6c8fbe75.png)

Essentially, it should include the square brackets around the address. I noticed another issue on another project that had the same problem and provides links to the RFC's https://github.com/dotnet/runtime/issues/25661#issuecomment-377023158

While tweaking the `Host` header, I noticed the following *if* statement which complicated the code and as far as I can tell guarded dead code (as it expects the `miscptr` to contain `://`) and the only effect of the statement was to set `webtarget = null` due to `strstr`.
https://github.com/vanhauser-thc/thc-hydra/blob/c2260d2c5d55a40e5ed51d9f995b31e425a095d1/hydra-http-form.c#L1247

I tried different things to execute this code guarded by the above *if*, with the most obvious being something of the following form:
```plaintext
$ hydra -l a -p a 'http-form-post://ptsv2.com/http://ptsv2.com/t/5sysq-1605183971/post:user=^USER^&password=^PASS^:Sorry'
```
But this just confused some code in `hydra.c`:
```plaintext
[ERROR] the variables argument needs at least the strings ^USER^, ^PASS^, ^USER64^ or ^PASS64^: //ptsv2.com/t/5sysq-1605183951/post
```
In the end, I just removed it as it simplified the implementation. If I'm mistaken and this *if* statement is useful, let me know and Ill update this PR :wink:

Finally, the second commit contains two minor changes to fix warnings flagged up by the compiler.