### PR TITLE
Optimize burst http service and telnet service

### DIFF
--- a/hydra-http.c
+++ b/hydra-http.c
@@ -504,7 +504,10 @@ int32_t service_http_init(char *ip, int32_t sp, unsigned char options, char *mis
       }
 
       match_status_code = atoi(status_code);
-      free(status_code);
+      
+      if (debug) {
+        hydra_report(stdout, "Find match reply status code: %d", match_status_code);
+      }
     }
   }
   return 0;
@@ -517,8 +520,8 @@ void usage_http(const char *service) {
          "NTLM or MD5\n"
          " (h|H)=My-Hdr\\: foo   to send a user defined HTTP header with each "
          "request\n"
-         " (c|C)=check for status code in the HTTP reply. If the reply status "
-         " code matches it, it is judged as successful \n"
+         " (c|C)=check for status code in the HTTP reply. If the reply status code\n"
+         "       matches it, it is judged as successful \n"
          " (F|S)=check for text in the HTTP reply. S= means if this text is "
          "found, a\n"
          "       valid account has been found, F= means if this string is "

--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -37,12 +37,14 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
       return 1;
 
     if (strchr(buf, '/') != NULL || strchr(buf, '>') != NULL || strchr(buf, '%') != NULL || strchr(buf, '$') != NULL || strchr(buf, '#') != NULL) {
-      hydra_report_found_host(port, ip, "telnet", fp);
-      hydra_completed_pair_found();
-      free(buf);
-      if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
-        return 3;
-      return 1;
+      if (strstr(buf, "ailed") == NULL) {
+        hydra_report_found_host(port, ip, "telnet", fp);
+        hydra_completed_pair_found();
+        free(buf);
+        if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
+          return 3;
+        return 1;
+      }
     }
     (void)make_to_lower(buf);
 


### PR DESCRIPTION
Some http authentication servers will return a non-401 status code when the password is attempted more than once, which leads to false positives, Of course the vast majority of me doesn't know what the successful login reply content, so I can't tell by the content

The addition of parameters makes it possible to determine success or failure based on the reply status code:

`(c|C)=check for status code in the HTTP reply. If the reply status code
            matches it, it is judged as successful`

---
Some telnet servers will have a % sign in the prefix after a failed login, which also leads to false success reports, which are dealt with it