### PR TITLE
hydra-gtk: update to gtk3

### DIFF
--- a/hydra-gtk/configure.in
+++ b/hydra-gtk/configure.in
@@ -10,7 +10,7 @@ AC_PROG_CC
 AM_PROG_CC_STDC
 AC_HEADER_STDC
 
-pkg_modules="gtk+-2.0 >= 2.0.0"
+pkg_modules="gtk+-3.0 >= 3.24.24"
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])
 AC_SUBST(PACKAGE_CFLAGS)
 AC_SUBST(PACKAGE_LIBS)


### PR DESCRIPTION
gtk3 is more modern and successor to the old gtk2

![Screenshot_20211122-135302](https://user-images.githubusercontent.com/64093255/142919149-d215e02d-d550-448f-9bb8-8637d44ca8c1.png)
