### PR TITLE
fix mongodb module not using specified port

### DIFF
--- a/hydra-mongodb.c
+++ b/hydra-mongodb.c
@@ -72,7 +72,7 @@ int32_t start_mongodb(int32_t s, char *ip, int32_t port, unsigned char options, 
   mongoc_log_set_handler(NULL, NULL);
   bson_init(&q);
 
-  snprintf(uri, sizeof(uri), "mongodb://%s:%s@%s/?authSource=%s", login, pass, hydra_address2string(ip), miscptr);
+  snprintf(uri, sizeof(uri), "mongodb://%s:%s@%s:%d/?authSource=%s", login, pass, hydra_address2string(ip), port, miscptr);
   client = mongoc_client_new(uri);
   if (!client)
     return 3;


### PR DESCRIPTION
mongodb module does not use specified due to omission of the port argument in the string formatter.