### PR TITLE
configure: openssl / memcached build fix

### DIFF
--- a/configure
+++ b/configure
@@ -998,11 +998,9 @@ echo "Checking for Memcached (libmemcached/memcached.h) ..."
     if [ "X" = "X$MCACHED_IPATH" ]; then
         if [ -f "$i/memcached.h" ]; then
             MCACHED_IPATH="$i"
-        fi
-        if [ -f "$i/libmemcached/memcached.h" ]; then
+        elif [ -f "$i/libmemcached/memcached.h" ]; then
             MCACHED_IPATH="$i/libmemcached"
-        fi
-        if [ -f "$i/libmemcached-1.0/memcached.h" ]; then
+        elif [ -f "$i/libmemcached-1.0/memcached.h" ]; then
             MCACHED_IPATH="$i/libmemcached-1.0"
         fi
     fi


### PR DESCRIPTION
On Debian/Ubuntu, compilation against openssl 3.0 causes a failure to
find INT_MAX, despite the openssl headers including limits.h.  However,
the fact that the libmemcached-dev package provides both
/usr/include/libmemcached{,-1.0} directories, both of which contain
memcached.h, mean that MCACHED_IPATH ends up set to the libmemcached-1.0
one, which contains a limits.h, which shadows /usr/include/limits.h.
Don't do that.

Not sure how this plays out in other build environments, so feel free to
decline or suggest changes.  Thanks!