### PR TITLE
Fix memory leak in radmin2

### DIFF
--- a/hydra-radmin2.c
+++ b/hydra-radmin2.c
@@ -366,6 +366,7 @@ void service_radmin2(char *ip, int32_t sp, unsigned char options, char *miscptr,
       hydra_report(stderr, "Error: Child with pid %d terminating, protocol error\n", (int32_t)getpid());
       hydra_child_exit(2);
     }
+    free(msg);
   }
 #endif
 }


### PR DESCRIPTION
`msg` is calloc'd a few lines above via `msg = buffer2message(buffer);`.
The check afterwards either exits the process on success or restarts the
loop without free'ing `msg`.