### PR TITLE
hydra-wizard is missing 'eval'

### DIFF
--- a/hydra-wizard.sh
+++ b/hydra-wizard.sh
@@ -41,4 +41,4 @@ echo
 read -p "Do you want to run the command now? [Y/n] " yn
 test "$yn" = "n" -o "$yn" = "N" && { echo Exiting. ; exit 0 ; }
 echo
-hydra $users $passs -u $pws $ports $opts $targets $service
+eval hydra $users $passs -u $pws $ports $opts $targets $service


### PR DESCRIPTION
Running hydra-wizard generates the correct command string but fails to execute
```[ERROR] optional parameter must start with a '/' slash!```

The error is caused by the single quotes in the `opts` parameter, as it is interpreted as a character included in the module options string. Removing the `'` chars in opts fixes it too but I'm concerned that could affect some module options. Using `eval` makes more sense

I know this script has not been maintained for a long time, but it's still working and I find it useful. I've made it the default command for the hydra menu entry in Kali Linux. That way the user can run hydra-wizard from the menu instead of only seeing the help output. That's the reason why I'm interested in fixing this

https://gitlab.com/kalilinux/packages/kali-menu/-/blob/b692a3644066bfa80dc8d7231f01019dd520ff18/desktop-files/kali-hydra.desktop#L5