### PR TITLE
Makefile.am: add -D_GNU_SOURCE for strcasestr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ WARN_CLANG=-Wformat-nonliteral -Wstrncat-size -Wformat-security -Wsign-conversio
 WARN_GCC=-Wformat=2 -Wformat-overflow=2 -Wformat-nonliteral -Wformat-truncation=2 -Wnull-dereference -Wstrict-overflow=2 -Wstringop-overflow=4 -Walloca-larger-than=4096 -Wtype-limits -Wconversion -Wtrampolines -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -fno-common -Wcast-align
 CFLAGS ?= -g
 OPTS=-I. -O3 $(CFLAGS) -fcommon
+CPPFLAGS += -D_GNU_SOURCE
 # -Wall -g -pedantic
 LIBS=-lm
 DESTDIR ?=


### PR DESCRIPTION
strcasestr is not a standard function and per
the man page, needs -D_GNU_SOURCE to be visible.

Fixes a build error:
```
hydra-rtsp.c:20:7: error: implicit declaration of function ‘strcasestr’; did you mean ‘strcasecmp’? [-Werror=implicit-function-declaration]
   20 |   if (strcasestr(s, "401 Unauthorized") != NULL) {
      |       ^~~~~~~~~~
      |       strcasecmp
```

Signed-off-by: Sam James <sam@gentoo.org>