### PR TITLE
fix: program stuck when mongodb user is empty

### DIFF
--- a/hydra-mongodb.c
+++ b/hydra-mongodb.c
@@ -72,10 +72,17 @@ int32_t start_mongodb(int32_t s, char *ip, int32_t port, unsigned char options, 
   mongoc_log_set_handler(NULL, NULL);
   bson_init(&q);
 
-  snprintf(uri, sizeof(uri), "mongodb://%s:%s@%s:%d/?authSource=%s", login, pass, hydra_address2string(ip), port, miscptr);
+  if (login[0] == '\0' && pass[0] == '\0') {
+    snprintf(uri, sizeof(uri), "mongodb://%s:%d/?authSource=%s", hydra_address2string(ip), port, miscptr);
+  } else {
+    snprintf(uri, sizeof(uri), "mongodb://%s:%s@%s:%d/?authSource=%s", login, pass, hydra_address2string(ip), port, miscptr);
+  }
+
   client = mongoc_client_new(uri);
-  if (!client)
+  if (!client) {
+    hydra_completed_pair_skip();
     return 3;
+  }
 
   mongoc_client_set_appname(client, "hydra");
   collection = mongoc_client_get_collection(client, miscptr, "test");


### PR DESCRIPTION
## Summary

Hydra gets stuck When brute force mongodb with empty username and empty password.


## Detail 

- Hydra version: build from master branch

```
$ hydra -l "" -p "" -I  -v mongodb://127.0.0.1

Hydra v9.5-dev (c) 2023 by van Hauser/THC & David Maciejak - Please do not use in military or secret service organizations, or for illegal purposes (this is non-binding, these *** ignore laws and ethics anyway).

Hydra (https://github.com/vanhauser-thc/thc-hydra) starting at 2023-02-10 07:29:24
[INFO] The mongodb db wasn't passed so using admin by default
[DATA] max 1 task per 1 server, overall 1 task, 1 login try (l:1/p:1), ~1 try per task
[DATA] attacking mongodb://127.0.0.1:27017/
[VERBOSE] Resolving addresses ... [VERBOSE] resolving done
[INFO] Using default database "admin"

```
Then it stucked...




## Background

The simple way to start mongodb in docker has not any authentication, you can just connect it with no username and no password.

```
docker run --name mongo --rm -p 27017:27017 -d mongo
```
