### PR TITLE
edit mongodb moudle error

### DIFF
--- a/hydra-mongodb.c
+++ b/hydra-mongodb.c
@@ -97,11 +97,11 @@ int32_t start_mongodb(int32_t s, char *ip, int32_t port, unsigned char options, 
       mongoc_collection_destroy(collection);
       mongoc_client_destroy(client);
       mongoc_cleanup();
-      hydra_completed_pair_skip();
+      hydra_completed_pair();
       if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0) {
         return 3;
       }
-      return 2;
+      return 1;
     }
   }
 


### PR DESCRIPTION
I found this error while using hydra for multi-password testing against mongodb.
In the original code, if the tested username and password pair is wrong, **hydra_completed_pair_skip()** will be called, and this time a flag will be set to "f", that is, username identified as invalid. Then, **hydra_skip_user()** is called afterwards, which causes the username to be skipped for this test. If there are other correct passwords in the password list, they will not be tested.
![image](https://user-images.githubusercontent.com/64568730/222174756-36ffa2a4-d7f9-410b-bddb-7f7995147366.png)

So the **hydra_completed_pair_skip()** function should be changed to **hydra_completed_pair()** so that the user name is not skipped.

Also, if the password test fails, returning 2 will exit the child thread, which is wrong. **Should return 1**, continue with the next test.
