### PR TITLE
Fixed #868 on vanhauser-thc/thc-hydra

### DIFF
--- a/hydra-rtsp.c
+++ b/hydra-rtsp.c
@@ -6,7 +6,9 @@
 //
 //
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "hydra-mod.h"
 #include "sasl.h"


### PR DESCRIPTION
There was a `_GNU_SOURCE` redefined warning that is no longer there.

Cheers.