### PR TITLE
Fix "make" error

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -390,7 +390,7 @@ char *stringify_headers(ptr_header_node *ptr_head) {
 }
 
 int32_t parse_options(char *miscptr, ptr_header_node *ptr_head) {
-  char *ptr, *ptr2;
+  char *ptr, *ptr2, *tmp;
 
   if (miscptr == NULL)
     return 1;
@@ -440,7 +440,7 @@ int32_t parse_options(char *miscptr, ptr_header_node *ptr_head) {
       break;
     case '1':
       code_401_is_failure = 1;
-      char *tmp = strchr(miscptr, ':');
+      *tmp = strchr(miscptr, ':');
       if (tmp)
         miscptr = tmp + 1;
       else
@@ -448,7 +448,7 @@ int32_t parse_options(char *miscptr, ptr_header_node *ptr_head) {
       break;
     case '2':
       code_302_is_success = 1;
-      char *tmp = strchr(miscptr, ':');
+      *tmp = strchr(miscptr, ':');
       if (tmp)
         miscptr = tmp + 1;
       else


### PR DESCRIPTION
Variable 'tmp' was moved to a higher scope in the parse_options function of hydra-http-form.c. This change was necessary to prevent duplicate declarations in the different switch case blocks. This PR fix "make" error : 
```
hydra-http-form.c: In function ‘parse_options’:
hydra-http-form.c:451:13: error: redefinition of ‘tmp’
  451 |       char *tmp = strchr(miscptr, ':');
      |             ^~~
hydra-http-form.c:443:13: note: previous definition of ‘tmp’ with type ‘char *’
  443 |       char *tmp = strchr(miscptr, ':');
      |             ^~~
make: *** [Makefile:81 : hydra-http-form.o] Erreur 1
```