### PR TITLE
fix smb password expired vs account expired confusion

### DIFF
--- a/hydra-smb.c
+++ b/hydra-smb.c
@@ -1304,13 +1304,12 @@ int32_t start_smb(int32_t s, char *ip, int32_t port, unsigned char options, char
       hydra_report(stderr, "[INFO] LM dialect may be disabled, try LMV2 instead\n");
     hydra_completed_pair_skip();
   } else if (SMBerr == 0x000024) { /* change password on next login [success] */
-    hydra_report(stdout, "[%d][smb] Host: %s Account: %s Error: ACCOUNT_CHANGE_PASSWORD\n", port, ipaddr_str, login);
+    hydra_report(stdout, "[%d][smb] Host: %s Account: %s Information: ACCOUNT_CHANGE_PASSWORD\n", port, ipaddr_str, login);
     hydra_completed_pair_found();
   } else if (SMBerr == 0x00006D) { /* STATUS_LOGON_FAILURE */
     hydra_completed_pair();
   } else if (SMBerr == 0x000071) { /* password expired */
-    if (verbose)
-      fprintf(stderr, "[%d][smb] Host: %s Account: %s Error: PASSWORD EXPIRED\n", port, ipaddr_str, login);
+    hydra_report(stdout, "[%d][smb] Host: %s Account: %s Information: PASSWORD EXPIRED\n", port, ipaddr_str, login);
     hydra_completed_pair_found();
   } else if ((SMBerr == 0x000072) || (SMBerr == 0xBF0002)) { /* account disabled */ /* BF0002 on w2k */
     if (verbose)

--- a/hydra-smb.c
+++ b/hydra-smb.c
@@ -1280,8 +1280,8 @@ int32_t start_smb(int32_t s, char *ip, int32_t port, unsigned char options, char
   } else if (SMBerr == 0x000193) { /* Valid password, account expired  */
     hydra_report(stdout, "[%d][smb] Host: %s Account: %s Valid password, account expired\n", port, ipaddr_str, login);
     hydra_report_found_host(port, ip, "smb", fp);
-    hydra_completed_pair_found();
-  } else if ((SMBerr == 0x000224) || (SMBerr == 0xC20002)) { /* Valid password, account expired  */
+    hydra_completed_pair_skip();
+  } else if ((SMBerr == 0x000224) || (SMBerr == 0xC20002)) { /* Valid password, password expired  */
     hydra_report(stdout,
                  "[%d][smb] Host: %s Account: %s Valid password, password "
                  "expired and must be changed on next logon\n",
@@ -1311,7 +1311,7 @@ int32_t start_smb(int32_t s, char *ip, int32_t port, unsigned char options, char
   } else if (SMBerr == 0x000071) { /* password expired */
     if (verbose)
       fprintf(stderr, "[%d][smb] Host: %s Account: %s Error: PASSWORD EXPIRED\n", port, ipaddr_str, login);
-    hydra_completed_pair_skip();
+    hydra_completed_pair_found();
   } else if ((SMBerr == 0x000072) || (SMBerr == 0xBF0002)) { /* account disabled */ /* BF0002 on w2k */
     if (verbose)
       fprintf(stderr, "[%d][smb] Host: %s Account: %s Error: ACCOUNT_DISABLED\n", port, ipaddr_str, login);


### PR DESCRIPTION
- If SMB password is MUST_CHANGE or EXPIRED, it is still valid, it is possible to change it remotely, so it should be returned as valid.
- If the _account_ is EXPIRED, it is no longer usable, even if the password is ok. It should be returned as invalid.

Testing is in this thread: https://twitter.com/an0n_r0/status/1731109539204710416

Originally Hydra returned valid if the account was expired but invalid if the password was expired. It is wrong, it should be exactly the opposite: valid if password was expired, but invalid if account was expired.
