### PR TITLE
Bump Debian version in Dockerfile to Bookworm 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG HYDRA_VERSION="github"
 


### PR DESCRIPTION
Since Debian Buster's LTS support ends next month, I suggest updating the base image in the Dockerfile to Debian Bookworm.