### PR TITLE
Add distributed computing

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -1597,7 +1597,6 @@ char *hydra_reverse_login(int32_t head_no, char *login) {
 
 
 FILE *hydra_divide_file(FILE *file, uint32_t my_segment, uint32_t num_segments){
-  fprintf(stdout, "Dividing file...\n");
 
   if(my_segment > num_segments){
     fprintf(stderr, "[ERROR] in option -D XofY, X must not be greater than Y: %s\n", hydra_options.passfile);
@@ -1610,11 +1609,7 @@ FILE *hydra_divide_file(FILE *file, uint32_t my_segment, uint32_t num_segments){
 
   uint32_t line_number = 0;
 
-  double total_lines;
-  if (total_lines = countlines(file,0))
-    fprintf(stdout, "There are %f lines int the wordlist", total_lines);
-  else
-    fprintf(stderr, "Something went wrong in the counting of lines");
+  double total_lines = countlines(file,0);
 
   if(num_segments > total_lines){
     fprintf(stderr, "[ERROR] in option -D XofY, Y must not be greater than the total number of lines in the file to be divided: %s\n", hydra_options.passfile);
@@ -2395,7 +2390,7 @@ int main(int argc, char *argv[]) {
             exit(EXIT_FAILURE);
         }
       else{
-        fprintf(stdout, "successfully set X to %d and Y to %d\n", my_segment, num_segments);
+        fprintf(stdout, "-D: successfully set X to %d and Y to %d\n", my_segment, num_segments);
       }
       break;
     case 'h':

--- a/hydra.c
+++ b/hydra.c
@@ -1638,7 +1638,6 @@ FILE *hydra_divide_file(FILE *file, uint32_t my_segment, uint32_t num_segments){
   int filetag = rand();
 
   sprintf(output_file_name, "segment_%d_%d.txt",filetag, my_segment);
-  fprintf(stdout, "writing successful\n");
   output_file = fopen(output_file_name, "w");
 
   if(!output_file){

--- a/hydra.c
+++ b/hydra.c
@@ -521,6 +521,8 @@ void help(int32_t ext) {
                     "instead of -L/-P options\n"
                     "  -M FILE   list of servers to attack, one entry per "
                     "line, ':' to specify port\n");
+  PRINT_NORMAL(ext, "  -D XofY   Divide wordlist into Y segments and use the "
+                    "Xth segment.\n");
   PRINT_EXTEND(ext, "  -o FILE   write found login/password pairs to FILE instead of stdout\n"
                     "  -b FORMAT specify the format for the -o FILE: text(default), json, "
                     "jsonv1\n"

--- a/hydra.c
+++ b/hydra.c
@@ -1591,6 +1591,15 @@ char *hydra_reverse_login(int32_t head_no, char *login) {
   return hydra_heads[head_no]->reverse;
 }
 
+void skip_passwords(int skips){
+  for(int i=0; i<skips; i++){
+    //if(*hydra_target[target_no]->pass_no >= hydra_brains.countpass)
+    while(*hydra_target[target_no]->pass_ptr != 0)
+      hydra_target[target_no]->pass_ptr++;
+    hydra_target[target_no]->pass_ptr++;
+  }
+}
+
 int32_t hydra_send_next_pair(int32_t target_no, int32_t head_no) {
   // variables moved to save stack
   snpdone = 0;
@@ -1750,9 +1759,7 @@ int32_t hydra_send_next_pair(int32_t target_no, int32_t head_no) {
                   return hydra_send_next_pair(target_no, head_no);
               } else {
                 hydra_targets[target_no]->pass_ptr++;
-                while (*hydra_targets[target_no]->pass_ptr != 0)
-                  hydra_targets[target_no]->pass_ptr++;
-                hydra_targets[target_no]->pass_ptr++;
+                skip_passwords(1);
               }
               if ((hydra_options.try_password_same_as_login && strcmp(hydra_heads[head_no]->current_pass_ptr, hydra_heads[head_no]->current_login_ptr) == 0) || (hydra_options.try_null_password && strlen(hydra_heads[head_no]->current_pass_ptr) == 0) || (hydra_options.try_password_reverse_login && strcmp(hydra_heads[head_no]->current_pass_ptr, hydra_reverse_login(head_no, hydra_heads[head_no]->current_login_ptr)) == 0)) {
                 hydra_brains.sent++;

--- a/hydra.h
+++ b/hydra.h
@@ -194,6 +194,7 @@ typedef struct {
   int32_t cidr;
   int32_t time_next_attempt;
   output_format_t outfile_format;
+  char *distributed; // Use distributed computing by splitting user files on the fly
   char *login;
   char *loginfile;
   char *pass;


### PR DESCRIPTION
resolves #386 

Added command line option to divide up wordlists on the fly. multiple processes or servers could be launched at once to  each use different parts of the wordlist, but there is no synchronisation or reporting of success as of yet, so this would have to be done manually.