### PR TITLE
POP3 CAPA response fix

### DIFF
--- a/hydra-pop3.c
+++ b/hydra-pop3.c
@@ -109,7 +109,7 @@ char *pop3_read_server_capacity(int32_t sock) {
           buf[strlen(buf) - 1] = 0;
         if (buf[strlen(buf) - 1] == '\r')
           buf[strlen(buf) - 1] = 0;
-        if (*(ptr) == '.' || *(ptr) == '-')
+        if (buf[strlen(buf) - 1] == '.' || *(ptr) == '.' || *(ptr) == '-')
           resp = 1;
       }
     }


### PR DESCRIPTION
Some POP3 servers contain many capabilities, so `+OK` and `\r\n.\r\n` Contained in different blocks, and the tool is looped. This code corrects this behavior