### PR TITLE
Fix Add NULL check to prevent NULL pointer dereference in start_redis( )

### DIFF
--- a/hydra-redis.c
+++ b/hydra-redis.c
@@ -24,6 +24,11 @@ int32_t start_redis(int32_t s, char *ip, int32_t port, unsigned char options, ch
     return 1;
   }
   buf = hydra_receive_line(s);
+  if (buf == NULL) {
+    hydra_report(stderr, "[ERROR] Failed to receive response from Redis server.\n");
+    return 3;
+  }
+
   if (buf[0] == '+') {
     hydra_report_found_host(port, ip, "redis", fp);
     hydra_completed_pair_found();


### PR DESCRIPTION
### Describe

This patch fixes a potential NULL pointer dereference in the `start_redis()` function.

The function `hydra_receive_line()` is used to receive the Redis server’s response, and its return value is stored in the `buf` pointer. However, the code assumes that `buf` is always valid and directly accesses `buf[0]` without checking for NULL. If `hydra_receive_line()` fails (e.g., due to a memory allocation error or socket error), it may return NULL, which would result in a segmentation fault when `buf[0]` is accessed.

This patch adds a defensive NULL check right after the `hydra_receive_line()` call and logs the error using `hydra_report()` before returning.

### Expected behavior

If `hydra_receive_line()` fails and returns NULL, the program should handle it gracefully by:

- Logging an appropriate error message
- Returning early without crashing

### Actual behavior

Currently, if `hydra_receive_line()` returns NULL (e.g., on memory or socket failure), the code dereferences `buf[0]` unconditionally.

This results in undefined behavior or a crash due to a NULL pointer dereference. This patch prevents a potential NULL pointer dereference in `start_redis()` by adding a missing NULL check. It follows the existing error-handling style and improves stability without changing normal behavior.

Thanks for reviewing.