### PR TITLE
Fix -M option ignoring -m parameter for non-path services

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -3710,7 +3710,7 @@ int main(int argc, char *argv[]) {
           hydra_targets[i]->miscptr = tmpptr3;
         }
         else
-          hydra_targets[i]->miscptr = "/";
+          hydra_targets[i]->miscptr = hydra_options.miscptr;
 
         while (*tmpptr != 0)
           tmpptr++;


### PR DESCRIPTION
When using the `-M` flag to specify multiple targets from a file, hydra incorrectly overwrites the `-m` (miscptr) parameter with `"/"` for targets that don't specify a path. This breaks services that use miscptr for non-path configuration.

## Example of the Bug
```bash
# This command fails with "unable to parse: /" errors
hydra -m "workgroup:{hiboxy}" -l user -p pass -M targets.txt smb2

# Where targets.txt contains:
10.130.10.4
10.130.10.5
```

## Root Cause
In commit 79f7d52, support was added for per-target paths in `-M` files (e.g., `192.168.1.1:80/admin`). However, the implementation defaults to `"/"` when no path is specified, which is incorrect for:
- SMB services (need `workgroup:{domain}`)
- SNMP services (need version info)
- MongoDB (needs database name)
- Other services using miscptr for non-path parameters

## The Fix
Changed line 3713 in hydra.c from:
```c
hydra_targets[i]->miscptr = "/";
```
to:
```c
hydra_targets[i]->miscptr = hydra_options.miscptr;
```

This ensures targets inherit the `-m` parameter value (or service-specific defaults) when no per-target path is specified in the file.

## Behavior After Fix
- Services requiring miscptr configuration (SMB, SNMP, etc.) work correctly with `-M`
- HTTP services still default to `"/"` (already set in `hydra_options.miscptr`)
- Per-target paths in `-M` files still work (`192.168.1.1:80/admin`)
- The `-m` parameter is properly inherited by all targets

## Testing
Tested with SMB service using multiple targets without paths (inherits `-m` value)

HTTP services still preserve default paths of `"/"`

This is a one-line fix that restores the correct behavior while maintaining the per-target path feature.