### PR TITLE
Fix: telnet compilation error in hydra-telnet.c from PR #1053

### DIFF
--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -1,5 +1,12 @@
 #include "hydra-mod.h"
+#include "hydra-telnet.h"
 #include <ctype.h>
+
+char *telcmds[] = {
+  "EOF", "SUSP", "ABORT", "EOR",
+  "SE", "NOP", "DMARK", "BRK", "IP", "AO", "AYT", "EC",
+  "EL", "GA", "SB", "WILL", "WONT", "DO", "DONT", "IAC", 0,
+};
 
 extern char *HYDRA_EXIT;
 char *buf;

--- a/hydra-telnet.h
+++ b/hydra-telnet.h
@@ -1,0 +1,26 @@
+#ifndef HYDRA_TELNET_DEFS_H
+#define HYDRA_TELNET_DEFS_H
+
+#define IAC 255   /* interpret as command: */
+#define DONT 254  /* you are not to use option */
+#define DO 253    /* please, you use option */
+#define WONT 252  /* I won't use option */
+#define WILL 251  /* I will use option */
+#define SB 250    /* interpret as subnegotiation */
+#define GA 249    /* you may reverse the line */
+#define EL 248    /* erase the current line */
+#define EC 247    /* erase the current character */
+#define AYT 246   /* are you there */
+#define AO 245    /* abort output--but let prog finish */
+#define IP 244    /* interrupt process--permanently */
+#define BREAK 243 /* break */
+#define DM 242    /* data mark--for connect. cleaning */
+#define NOP 241   /* nop */
+#define SE 240    /* end sub negotiation */
+#define EOR 239   /* end of record (transparent mode) */
+#define ABORT 238 /* Abort process */
+#define SUSP 237  /* Suspend process */
+#define xEOF 236  /* End of file: EOF is already used... */
+#define SYNCH 242 /* for telfunc calls */
+extern char *telcmds[];
+#endif


### PR DESCRIPTION
Fixes the compile errors from the #1053 merge of **hydra-telnet.c**.

The new **hydra-telnet.c** file removed the **arpa/telnet.h** header; however functionality of the file was never added back, and protocols like (IAC, WILL, DONT, etc) and telcmds functions were missing. This just adds the protocols in a new file **hydra-telnet.h** and allows the telnet service to compile properly.

Changes:
- Added back Telnet constants defined in arpa/telnet.h to hydra-telnet.h.
- moved array definition to the main .c file and used hydra-telnet.h file to make it cleaner.
- fix allowed compilation on Linux "6.18.4-1-MANJARO".

 