### PR TITLE
Fix SSH port from CLI being overridden by ~/.ssh/config

### DIFF
--- a/hydra-ssh.c
+++ b/hydra-ssh.c
@@ -41,8 +41,9 @@ int32_t start_ssh(int32_t s, char *ip, int32_t port, unsigned char options, char
     }
 
     session = ssh_new();
-    ssh_options_set(session, SSH_OPTIONS_PORT, &port);
     ssh_options_set(session, SSH_OPTIONS_HOST, hydra_address2string(ip));
+    ssh_options_parse_config(session, NULL);
+    ssh_options_set(session, SSH_OPTIONS_PORT, &port);
     ssh_options_set(session, SSH_OPTIONS_USER, login);
     ssh_options_set(session, SSH_OPTIONS_TIMEOUT, &hydra_options.waittime);
     ssh_options_set(session, SSH_OPTIONS_COMPRESSION_C_S, "none");
@@ -186,8 +187,9 @@ int32_t service_ssh_init(char *ip, int32_t sp, unsigned char options, char *misc
     printf("[INFO] Testing if password authentication is supported by "
            "ssh://%s@%s:%d\n",
            miscptr == NULL ? "hydra" : miscptr, hydra_address2string_beautiful(ip), port);
-  ssh_options_set(session, SSH_OPTIONS_PORT, &port);
   ssh_options_set(session, SSH_OPTIONS_HOST, hydra_address2string(ip));
+  ssh_options_parse_config(session, NULL);
+  ssh_options_set(session, SSH_OPTIONS_PORT, &port);
   if (miscptr == NULL)
     ssh_options_set(session, SSH_OPTIONS_USER, "hydra");
   else

--- a/hydra-sshkey.c
+++ b/hydra-sshkey.c
@@ -40,8 +40,9 @@ int32_t start_sshkey(int32_t s, char *ip, int32_t port, unsigned char options, c
     }
 
     session = ssh_new();
-    ssh_options_set(session, SSH_OPTIONS_PORT, &port);
-    ssh_options_set(session, SSH_OPTIONS_HOST, hydra_address2string(ip));
+  ssh_options_set(session, SSH_OPTIONS_HOST, hydra_address2string(ip));
+  ssh_options_parse_config(session, NULL);
+  ssh_options_set(session, SSH_OPTIONS_PORT, &port);
     ssh_options_set(session, SSH_OPTIONS_USER, login);
     ssh_options_set(session, SSH_OPTIONS_COMPRESSION_C_S, "none");
     ssh_options_set(session, SSH_OPTIONS_COMPRESSION_S_C, "none");


### PR DESCRIPTION
Fixing issue recommended by issue#1039

1. Changes made to two files that call ssh_options_parse_config() before ssh_options_set so that command-line port takes priority over config file defaults.
2. libssh's ssh_connect() auto parses config files and overrides previously set options. By explicitly parsing first, then setting the port, the CLI value wins.

