### PR TITLE
fix(dpl4hydra): resolve dpl4hydra_full.csv from common install layouts (#1069)

### DIFF
--- a/dpl4hydra.sh
+++ b/dpl4hydra.sh
@@ -154,8 +154,34 @@ generate ()
 
 LC_ALL=C
 export LC_ALL
+
+# Resolve the directory holding dpl4hydra_full.csv. Distro packages have
+# substituted INSTALLDIR / LOCATION inconsistently over the years (some leave
+# trailing slashes, Fedora's package uses an absolute LOCATION that already
+# contains INSTALLDIR), which used to produce paths like
+# "/usr//usr/share/hydra/dpl4hydra_full.csv" — see issue #1069. Try a few
+# plausible layouts and pick the first one that holds the data file.
 DPLPATH="."
-test -r "$DPLPATH/dpl4hydra_full.csv" || DPLPATH="$INSTALLDIR/$LOCATION"
+if [ ! -r "$DPLPATH/dpl4hydra_full.csv" ]; then
+    for cand in \
+        "$LOCATION" \
+        "$INSTALLDIR/$LOCATION" \
+        "${INSTALLDIR%/}/${LOCATION#/}" \
+        "/usr/share/hydra" \
+        "/usr/local/etc" \
+        "/etc"
+    do
+        if [ -r "$cand/dpl4hydra_full.csv" ]; then
+            DPLPATH="$cand"
+            break
+        fi
+    done
+    # Fall back to the historical concat (with double-slash collapse) so the
+    # 'refresh' subcommand can still create the file the first time.
+    if [ "$DPLPATH" = "." ]; then
+        DPLPATH=`echo "${INSTALLDIR%/}/${LOCATION#/}" | sed 's|//*|/|g'`
+    fi
+fi
 FULLFILE="$DPLPATH/dpl4hydra_full.csv"
 OLDFILE="$DPLPATH/dpl4hydra_full.old"
 LOCALFILE="$DPLPATH/dpl4hydra_local.csv"

--- a/dpl4hydra.sh
+++ b/dpl4hydra.sh
@@ -163,19 +163,37 @@ export LC_ALL
 # plausible layouts and pick the first one that holds the data file.
 DPLPATH="."
 if [ ! -r "$DPLPATH/dpl4hydra_full.csv" ]; then
-    for cand in \
-        "$LOCATION" \
-        "$INSTALLDIR/$LOCATION" \
-        "${INSTALLDIR%/}/${LOCATION#/}" \
-        "/usr/share/hydra" \
-        "/usr/local/etc" \
-        "/etc"
-    do
-        if [ -r "$cand/dpl4hydra_full.csv" ]; then
-            DPLPATH="$cand"
-            break
-        fi
-    done
+    case "$LOCATION" in
+        /*)
+            for cand in \
+                "$LOCATION" \
+                "$INSTALLDIR/$LOCATION" \
+                "${INSTALLDIR%/}/${LOCATION#/}" \
+                "/usr/share/hydra" \
+                "/usr/local/etc" \
+                "/etc"
+            do
+                if [ -r "$cand/dpl4hydra_full.csv" ]; then
+                    DPLPATH="$cand"
+                    break
+                fi
+            done
+            ;;
+        *)
+            for cand in \
+                "$INSTALLDIR/$LOCATION" \
+                "${INSTALLDIR%/}/${LOCATION#/}" \
+                "/usr/share/hydra" \
+                "/usr/local/etc" \
+                "/etc"
+            do
+                if [ -r "$cand/dpl4hydra_full.csv" ]; then
+                    DPLPATH="$cand"
+                    break
+                fi
+            done
+            ;;
+    esac
     # Fall back to the historical concat (with double-slash collapse) so the
     # 'refresh' subcommand can still create the file the first time.
     if [ "$DPLPATH" = "." ]; then


### PR DESCRIPTION
Closes #1069.

## Background

`dpl4hydra.sh` resolves the path to its `dpl4hydra_full.csv` data file from two variables that `Makefile.am`'s install rule rewrites at install time:

```sh
INSTALLDIR=/usr/local
LOCATION=etc
...
DPLPATH="."
test -r "$DPLPATH/dpl4hydra_full.csv" || DPLPATH="$INSTALLDIR/$LOCATION"
```

Distro packages have substituted these inconsistently over the years:

| Source | INSTALLDIR | LOCATION | `$INSTALLDIR/$LOCATION` |
|---|---|---|---|
| upstream defaults | `/usr/local` | `etc` | `/usr/local/etc` |
| upstream `make install PREFIX=/usr` | `/usr` | `/etc` | `/usr//etc` |
| Fedora package (per #1069) | `/usr/` | `/usr/share/hydra/` | `/usr//usr/share/hydra/` |
| Kali / Debian | `/usr` | `share/hydra` | `/usr/share/hydra` |

The kernel tolerates the `//` doublings, but the Fedora layout is the one users actually hit, and the resulting `/usr//usr/share/hydra/` doesn't exist (the data files live at `/usr/share/hydra/`). The reporter saw:

```
$ dpl4hydra.sh refresh
... /usr/bin/dpl4hydra.sh: line 63: /usr//usr/share/hydra/dpl4hydra_index.tmp: No such file or directory
ERROR: Downloading data to disk failed. Network down?
rm: cannot remove '/usr//usr/share/hydra/dpl4hydra_index.tmp': No such file or directory
```

## Change

Replace the single `INSTALLDIR/LOCATION` concat with a small candidate-path search:

1. `$LOCATION` on its own — matches Fedora's substitution where LOCATION is already absolute and complete
2. `$INSTALLDIR/$LOCATION` — the historical upstream form
3. `${INSTALLDIR%/}/${LOCATION#/}` — slash-trimmed concat
4. `/usr/share/hydra` — common Debian/Kali layout
5. `/usr/local/etc` — upstream default
6. `/etc`

The first directory that actually holds `dpl4hydra_full.csv` wins. If none do (so the user is about to run `dpl4hydra.sh refresh` for the first time), keep the historical concat — slash-collapsed — so the file gets written where the active install layout expects it.

## Verification

Tested against three install layouts using the script with `INSTALLDIR` / `LOCATION` rewritten the way each distro substitutes them:

```
# upstream defaults
INSTALLDIR=/tmp/usr/local LOCATION=etc → /tmp/usr/local/etc/dpl4hydra_full.csv ✓

# Fedora (issue's reporter)
INSTALLDIR=/tmp/usr/ LOCATION=/tmp/usr/share/hydra/ → /tmp/usr/share/hydra/dpl4hydra_full.csv ✓

# Debian/Kali
INSTALLDIR=/tmp/usr LOCATION=share/hydra → /tmp/usr/share/hydra/dpl4hydra_full.csv ✓

# Nothing-found fallback (refresh-first-time case)
INSTALLDIR=/tmp/no/where/ LOCATION=etc → /tmp/no/where/etc (clean concat, no //)
```

Diff is `+27 / -1` lines, single file, POSIX-`sh` compatible (no bashisms).

## Notes

- Doesn't change the `Makefile.am` install rule — distros that already work keep working, and the Fedora/RHEL family layout starts working without their packagers having to revise their patch.
- If you'd prefer a smaller patch (e.g. just the slash-collapse without the candidate search), happy to scope down — the search is what makes Fedora's "absolute LOCATION" case work without extra distro patching.
