### PR TITLE
Fix premature success detection in telnet module

### DIFF
--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -268,9 +268,10 @@ static telnet_resp_t classify_response(const char *buffer) {
  * A literal ':' inside a value can be escaped as "\:" exactly as in the
  * http-form module, so success strings such as "Last login\:" are usable.
  *
- * The caller is expected to have already lower-cased miscptr; this routine
- * only splits and unescapes. The function is idempotent and safe to call
- * multiple times; previous values are released first.
+ * The prefix detection is case-insensitive so that both "S="/"F=" and the
+ * already-lower-cased "s="/"f=" produced by the call-site work the same
+ * way. The function is idempotent and safe to call multiple times;
+ * previous values are released first.
  */
 static void telnet_parse_miscptr(char *miscptr) {
   char *work, *seg_start, *p, *unescaped;
@@ -288,7 +289,7 @@ static void telnet_parse_miscptr(char *miscptr) {
   if (miscptr == NULL || *miscptr == 0)
     return;
 
-  has_prefix = (strncmp(miscptr, "s=", 2) == 0 || strncmp(miscptr, "f=", 2) == 0);
+  has_prefix = (strncasecmp(miscptr, "s=", 2) == 0 || strncasecmp(miscptr, "f=", 2) == 0);
 
   if (!has_prefix) {
     /* Legacy contract: whole value is a success substring. */
@@ -308,14 +309,14 @@ static void telnet_parse_miscptr(char *miscptr) {
     if (at_end || at_sep) {
       char saved = *p;
       *p = 0;
-      if (strncmp(seg_start, "s=", 2) == 0) {
+      if (strncasecmp(seg_start, "s=", 2) == 0) {
         if (user_success_str != NULL) {
           free(user_success_str);
           user_success_str = NULL;
         }
         unescaped = hydra_strrep(seg_start + 2, "\\:", ":");
         user_success_str = strdup(unescaped != NULL ? unescaped : seg_start + 2);
-      } else if (strncmp(seg_start, "f=", 2) == 0) {
+      } else if (strncasecmp(seg_start, "f=", 2) == 0) {
         if (user_failure_str != NULL) {
           free(user_failure_str);
           user_failure_str = NULL;

--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -12,55 +12,164 @@ extern const unsigned char HYDRA_EXIT[5];
 char *buf;
 int32_t no_line_mode;
 
-/* Comprehensive failure detection - merged from all provided patterns */
+/*
+ * Failure-message detection.
+ *
+ * Patterns are deliberately specific. Earlier revisions matched single
+ * generic tokens such as "wrong", "failed" or "too many" which frequently
+ * appear in legitimate banners, MOTDs and help text and therefore caused
+ * spurious false-negative behaviour. We only accept phrases that are
+ * unambiguously associated with an authentication failure.
+ *
+ * The buffer is copied and lower-cased defensively even though the
+ * call-sites already lower-case their input.
+ */
 static int is_failure(const char *buffer) {
   char temp[4096];
+
+  if (buffer == NULL)
+    return 0;
+
   strncpy(temp, buffer, sizeof(temp) - 1);
   temp[sizeof(temp) - 1] = 0;
   make_to_lower(temp);
 
   if (strstr(temp, "incorrect") != NULL ||
       strstr(temp, "invalid") != NULL ||
-      strstr(temp, "failed") != NULL ||
       strstr(temp, "denied") != NULL ||
       strstr(temp, "bad password") != NULL ||
+      strstr(temp, "bad passwords") != NULL ||
       strstr(temp, "authentication failed") != NULL ||
+      strstr(temp, "authentication failure") != NULL ||
+      strstr(temp, "authentication error") != NULL ||
+      strstr(temp, "authorization failed") != NULL ||
       strstr(temp, "login failed") != NULL ||
       strstr(temp, "login incorrect") != NULL ||
-      strstr(temp, "access denied") != NULL ||
-      strstr(temp, "wrong") != NULL ||
-      strstr(temp, "not allowed") != NULL ||
-      strstr(temp, "permission denied") != NULL ||
-      strstr(temp, "unable to authenticate") != NULL ||
-      strstr(temp, "information incomplete") != NULL ||
-      strstr(temp, "incorrect user/password") != NULL ||
-      strstr(temp, "please retry after") != NULL ||
-      strstr(temp, "bad password, bye-bye") != NULL ||
-      strstr(temp, "bad password,bye-bye") != NULL ||
-      strstr(temp, "bad password bye-bye") != NULL ||
       strstr(temp, "login failure") != NULL ||
+      strstr(temp, "access denied") != NULL ||
+      strstr(temp, "permission denied") != NULL ||
+      strstr(temp, "wrong password") != NULL ||
+      strstr(temp, "wrong login") != NULL ||
+      strstr(temp, "wrong username") != NULL ||
+      strstr(temp, "wrong credentials") != NULL ||
+      strstr(temp, "not allowed") != NULL ||
+      strstr(temp, "unable to authenticate") != NULL ||
+      strstr(temp, "too many attempts") != NULL ||
+      strstr(temp, "too many failures") != NULL ||
+      strstr(temp, "too many tries") != NULL ||
+      strstr(temp, "too many logins") != NULL ||
       strstr(temp, "user was locked") != NULL ||
+      strstr(temp, "account locked") != NULL ||
+      strstr(temp, "account is locked") != NULL ||
       strstr(temp, "ip has been blocked") != NULL ||
       strstr(temp, "cannot log on") != NULL ||
-      strstr(temp, "password is incorrect, left") != NULL ||
-      strstr(temp, "authorization failed") != NULL ||
-      strstr(temp, "error: authentication") != NULL ||
-      strstr(temp, "error: user was locked") != NULL ||
-      strstr(temp, "error: username or password") != NULL ||
+      strstr(temp, "please retry") != NULL ||
+      strstr(temp, "please try again") != NULL ||
+      strstr(temp, "please try it again") != NULL ||
+      strstr(temp, "username or password") != NULL ||
+      strstr(temp, "user name or password") != NULL ||
+      strstr(temp, "password is incorrect") != NULL ||
+      strstr(temp, "bye-bye") != NULL ||
       strstr(temp, "% bad passwords") != NULL ||
       strstr(temp, "% authentication failed") != NULL ||
       strstr(temp, "% login failure") != NULL ||
-      strstr(temp, "bye-bye") != NULL ||
-      strstr(temp, "can't resolve symbol") != NULL ||
-      strstr(temp, "too many") != NULL ||
       strstr(temp, "закрыт") != NULL ||
-      strstr(temp, "local: authentication failure") != NULL ||
-      strstr(temp, "please try it again") != NULL ||
-      strstr(temp, "username or password error") != NULL ||
-      strstr(temp, "user name or password is wrong") != NULL) {
+      strstr(temp, "local: authentication failure") != NULL) {
     return 1;
   }
   return 0;
+}
+
+/*
+ * Recognise password prompts. The caller is expected to have lower-cased
+ * the buffer; we use hydra_strcasestr for the multilingual stem matches
+ * to stay robust against partially lowered input.
+ */
+static int is_password_prompt(const char *buffer) {
+  if (buffer == NULL)
+    return 0;
+  return (hydra_strcasestr(buffer, "asswor") != NULL ||
+          hydra_strcasestr(buffer, "asscode") != NULL ||
+          hydra_strcasestr(buffer, "ennwort") != NULL ||
+          strstr(buffer, "passwd:") != NULL ||
+          strstr(buffer, "pass:") != NULL ||
+          strstr(buffer, "pwd:") != NULL ||
+          strstr(buffer, "pin:") != NULL ||
+          strstr(buffer, "пароль") != NULL ||
+          strstr(buffer, "contraseña") != NULL ||
+          strstr(buffer, "enter password") != NULL ||
+          strstr(buffer, "password for") != NULL);
+}
+
+/*
+ * Strict login-prompt detection used after credentials have been sent.
+ * Kept narrow on purpose: a post-login MOTD that contains "account:" or a
+ * bare "name:" must not be interpreted as the server re-asking for a
+ * username, otherwise we would discard a valid credential pair.
+ */
+static int is_login_prompt(const char *buffer) {
+  if (buffer == NULL)
+    return 0;
+  return ((strstr(buffer, "ogin:") != NULL && strstr(buffer, "last login") == NULL) ||
+          strstr(buffer, "sername:") != NULL);
+}
+
+/*
+ * Loose login-prompt detection used only while reading the initial banner
+ * to decide whether the server is in password-only mode. Matching extra
+ * tokens here is safe because the worst-case outcome is that a password-
+ * only server is treated as a username+password server (and we then fall
+ * back to sending the username, which is the documented default).
+ */
+static int is_login_prompt_banner(const char *buffer) {
+  if (buffer == NULL)
+    return 0;
+  if (is_login_prompt(buffer))
+    return 1;
+  return (strstr(buffer, "user:") != NULL ||
+          strstr(buffer, "login:") != NULL ||
+          strstr(buffer, "user id:") != NULL ||
+          strstr(buffer, "userid:") != NULL ||
+          strstr(buffer, "account:") != NULL ||
+          strstr(buffer, "логин:") != NULL ||
+          strstr(buffer, "user access verification") != NULL ||
+          strstr(buffer, "user name:") != NULL ||
+          strstr(buffer, "name:") != NULL);
+}
+
+/*
+ * Return non-zero when the buffer ends with a recognised shell-prompt
+ * character (after trimming trailing whitespace and CR/LF).
+ *
+ * The previous implementation looked for any of '/', '$', '#', '>' or '%'
+ * anywhere inside the buffer, which produced heavy false positives:
+ *   - '/' is part of nearly every path printed in a MOTD,
+ *   - '$' and '#' appear in pricing, version strings, comments, etc.,
+ *   - '%' appears in percentages ("100% loaded"),
+ *   - '>' appears in quoted text and arrows.
+ *
+ * Restricting the test to the final non-whitespace byte is the minimum
+ * structural cue that still recognises interactive shells (bash "$"/"#",
+ * csh "%", DOS/Cisco ">") while rejecting MOTD / banner false positives.
+ */
+static int has_shell_prompt(const char *buffer) {
+  const char *p;
+  size_t len;
+  char last;
+
+  if (buffer == NULL)
+    return 0;
+
+  len = strlen(buffer);
+  if (len == 0)
+    return 0;
+
+  p = buffer + len - 1;
+  while (p > buffer && (*p == '\r' || *p == '\n' || *p == ' ' || *p == '\t'))
+    p--;
+
+  last = *p;
+  return (last == '$' || last == '#' || last == '>' || last == '%');
 }
 
 int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE *fp) {
@@ -75,42 +184,22 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
   if (strlen(pass = hydra_get_next_password()) == 0)
     pass = empty;
 
-  /* Read initial banners after negotiation to detect prompt type */
+  /*
+   * Read initial banners to discover which prompt the server uses.
+   *
+   * This phase must NEVER declare success: no credential has been sent
+   * yet, so any structural cue here (a shell-prompt character inside a
+   * MOTD, a path in the banner, etc.) cannot prove valid authentication
+   * and was a major source of false positives in earlier revisions.
+   */
   while ((buf = hydra_receive_line(s)) != NULL) {
     make_to_lower(buf);
 
-    /* Early success detection */
-    if (strchr(buf, '/') != NULL || strchr(buf, '>') != NULL || strchr(buf, '%') != NULL ||
-        strchr(buf, '$') != NULL || strchr(buf, '#') != NULL) {
-      hydra_report_found_host(port, ip, "telnet", fp);
-      hydra_completed_pair_found();
-      free(buf);
-      if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
-        return 3;
-      return 1;
-    }
-
-    /* Enhanced password prompt detection (multilingual + variants) 
-     * Re-added: "ennwort" (German Kennwort) and "asscode" per vanhauser-thc request */
-    if (hydra_strcasestr(buf, "asswor") != NULL || 
-        hydra_strcasestr(buf, "asscode") != NULL ||
-        hydra_strcasestr(buf, "ennwort") != NULL ||
-        strstr(buf, "passwd:") != NULL || strstr(buf, "pass:") != NULL ||
-        strstr(buf, "pwd:") != NULL || strstr(buf, "pin:") != NULL ||
-        strstr(buf, "пароль:") != NULL || strstr(buf, "contraseña:") != NULL ||
-        strstr(buf, "enter password") != NULL || strstr(buf, "password for") != NULL) {
+    if (is_password_prompt(buf))
       password_prompt_seen = 1;
-    }
 
-    /* Enhanced username/login prompt detection */
-    if ((strstr(buf, "ogin:") != NULL && strstr(buf, "last login") == NULL) ||
-        strstr(buf, "sername:") != NULL || strstr(buf, "user:") != NULL ||
-        strstr(buf, "login:") != NULL || strstr(buf, "user id:") != NULL ||
-        strstr(buf, "userid:") != NULL || strstr(buf, "account:") != NULL ||
-        strstr(buf, "логин:") != NULL || strstr(buf, "user access verification") != NULL ||
-        strstr(buf, "name:") != NULL || strstr(buf, "user name:") != NULL) {
+    if (is_login_prompt_banner(buf))
       username_prompt_seen = 1;
-    }
 
     free(buf);
 
@@ -141,32 +230,25 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
         return 1;
     }
 
-    /* Wait for password prompt after sending username */
+    /*
+     * Wait for the password prompt after sending the username.
+     *
+     * This phase, like the banner phase above, must NEVER declare
+     * success. Only two outcomes are valid here:
+     *   - the server asks for a password   -> proceed to send it
+     *   - the server re-prompts for a login -> the username is wrong
+     */
     int32_t i = 0;
     do {
       if ((buf = hydra_receive_line(s)) == NULL)
         return 1;
 
-      if (strchr(buf, '/') != NULL || strchr(buf, '>') != NULL || strchr(buf, '%') != NULL ||
-          strchr(buf, '$') != NULL || strchr(buf, '#') != NULL) {
-        hydra_report_found_host(port, ip, "telnet", fp);
-        hydra_completed_pair_found();
-        free(buf);
-        if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
-          return 3;
-        return 1;
-      }
-
       (void)make_to_lower(buf);
-      
-      /* Check for password prompt - includes ennwort and asscode */
-      if (hydra_strcasestr(buf, "asswor") != NULL || 
-          hydra_strcasestr(buf, "asscode") != NULL || 
-          hydra_strcasestr(buf, "ennwort") != NULL)
+
+      if (is_password_prompt(buf))
         i = 1;
 
-      if (i == 0 && ((strstr(buf, "ogin:") != NULL && strstr(buf, "last login") == NULL) ||
-                     strstr(buf, "sername:") != NULL)) {
+      if (i == 0 && is_login_prompt(buf)) {
         free(buf);
         hydra_completed_pair();
         if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
@@ -194,26 +276,23 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
       return 1;
   }
 
-  /* Response handling after password */
+  /*
+   * Response handling after the password has been sent.
+   *
+   * Order of checks is significant and must be:
+   *   1) explicit failure message,
+   *   2) password re-prompt,
+   *   3) login re-prompt,
+   *   4) success (operator-supplied string OR a trailing shell prompt).
+   *
+   * Putting success last guarantees that a single response containing
+   * both a failure phrase and a stray prompt character (e.g. an error
+   * banner followed by "Login:") is correctly treated as a failure.
+   */
   while ((buf = hydra_receive_line(s)) != NULL) {
     make_to_lower(buf);
 
-    /* Success detection */
-    if ((miscptr != NULL && strstr(buf, miscptr) != NULL) ||
-        (miscptr == NULL && !is_failure(buf) &&
-         (strchr(buf, '/') != NULL || strchr(buf, '>') != NULL ||
-          strchr(buf, '$') != NULL || strchr(buf, '#') != NULL ||
-          strchr(buf, '%') != NULL ||
-          (buf[1] == '\xfd' && buf[2] == '\x18')))) {
-      hydra_report_found_host(port, ip, "telnet", fp);
-      hydra_completed_pair_found();
-      free(buf);
-      if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
-        return 3;
-      return 1;
-    }
-
-    /* Failure detection using comprehensive patterns */
+    /* 1) Explicit failure phrase wins over everything else. */
     if (is_failure(buf)) {
       free(buf);
       hydra_completed_pair();
@@ -222,12 +301,9 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
       return 2;
     }
 
-    /* Re-prompt for password -> try next password (includes ennwort/asscode) */
-    if (hydra_strcasestr(buf, "asswor") != NULL || 
-        hydra_strcasestr(buf, "asscode") != NULL ||
-        hydra_strcasestr(buf, "ennwort") != NULL ||
-        strstr(buf, "passwd:") != NULL ||
-        strstr(buf, "pass:") != NULL || strstr(buf, "pwd:") != NULL) {
+    /* 2) The server re-asks for a password -> the password was wrong;
+     *    feed the next candidate without dropping the connection. */
+    if (is_password_prompt(buf)) {
       hydra_completed_pair();
       free(buf);
       if (strlen(pass = hydra_get_next_password()) == 0)
@@ -249,11 +325,42 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
       continue;
     }
 
-    /* Re-prompt for login -> restart entire pair */
-    if (strstr(buf, "ogin:") != NULL || strstr(buf, "sername:") != NULL) {
+    /* 3) The server re-asks for a username -> the whole pair is wrong;
+     *    let the outer loop reconnect and try the next pair. */
+    if (is_login_prompt(buf)) {
       free(buf);
       hydra_completed_pair();
       return 2;
+    }
+
+    /* 4) Success detection.
+     *
+     *    - If the operator supplied a success string (-m / miscptr) we
+     *      require an exact substring match. This is the recommended
+     *      reliable mode and the only one that gives strong guarantees
+     *      against false positives.
+     *    - Otherwise we accept the response only when its last
+     *      non-whitespace byte is a recognised shell-prompt character.
+     *      Matching the prompt at the *end* of the line (instead of
+     *      anywhere inside it, as before) eliminates the bulk of the
+     *      structural false positives the previous logic produced.
+     */
+    if (miscptr != NULL) {
+      if (strstr(buf, miscptr) != NULL) {
+        hydra_report_found_host(port, ip, "telnet", fp);
+        hydra_completed_pair_found();
+        free(buf);
+        if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
+          return 3;
+        return 1;
+      }
+    } else if (has_shell_prompt(buf)) {
+      hydra_report_found_host(port, ip, "telnet", fp);
+      hydra_completed_pair_found();
+      free(buf);
+      if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
+        return 3;
+      return 1;
     }
 
     free(buf);
@@ -389,10 +496,18 @@ int32_t service_telnet_init(char *ip, int32_t sp, unsigned char options, char *m
 
 void usage_telnet(const char *service) {
   printf("Module telnet is optionally taking the string which is displayed after\n"
-         "a successful login (case insensitive), useful if default detection has false positives.\n\n"
-         "This improved version features:\n"
-         " - Automatic password-only mode detection and handling (e.g., Cisco, embedded devices)\n"
-         " - Multilingual prompt support (English, German, Russian, Spanish, etc.)\n"
-         " - Extensive failure message detection to avoid false positives\n"
+         "a successful login (case insensitive). Supplying this string is the\n"
+         "single most reliable way to avoid false positives and is strongly\n"
+         "recommended whenever the target's post-login banner is known.\n\n"
+         "Default success detection:\n"
+         " - Requires an explicit failure phrase to be absent\n"
+         " - Requires the response to END with a shell prompt character\n"
+         "   ('$', '#', '>' or '%%'); prompt characters appearing inside the\n"
+         "   buffer are no longer treated as success on their own\n"
+         " - Never declares success before the password has been sent\n\n"
+         "Features:\n"
+         " - Automatic password-only mode detection (Cisco, embedded devices)\n"
+         " - Multilingual prompt support (English, German, Russian, Spanish, ...)\n"
+         " - Specific failure-message patterns to minimise misclassification\n\n"
          "For password-only servers, use: hydra -l \"\" -P passwords.txt ip telnet\n");
 }

--- a/hydra-telnet.c
+++ b/hydra-telnet.c
@@ -13,6 +13,23 @@ char *buf;
 int32_t no_line_mode;
 
 /*
+ * Operator-supplied success / failure substrings parsed from the optional
+ * module parameter (miscptr). Either, both, or neither may be set.
+ *
+ *   - user_success_str : when non-NULL, the response must contain this
+ *                        substring to be reported as a successful login;
+ *                        replaces the structural shell-prompt heuristic.
+ *   - user_failure_str : when non-NULL, the response is treated as a
+ *                        failure if it contains this substring (in addition
+ *                        to the built-in failure phrase list).
+ *
+ * Both buffers are owned by this translation unit, are lower-cased at parse
+ * time, and live for the lifetime of the worker process.
+ */
+static char *user_success_str = NULL;
+static char *user_failure_str = NULL;
+
+/*
  * Failure-message detection.
  *
  * Patterns are deliberately specific. Earlier revisions matched single
@@ -78,6 +95,24 @@ static int is_failure(const char *buffer) {
     return 1;
   }
   return 0;
+}
+
+/*
+ * Failure detection that also honours the operator-supplied F= substring.
+ *
+ * The user-supplied pattern is checked first so an operator can override
+ * (or extend) the built-in heuristics for devices whose failure banners
+ * are not covered by is_failure(). The caller is expected to have lower-
+ * cased the buffer; user_failure_str is lower-cased at parse time so the
+ * comparison is effectively case-insensitive.
+ */
+static int is_failure_with_user(const char *buffer) {
+  if (buffer == NULL)
+    return 0;
+  if (user_failure_str != NULL && *user_failure_str != 0 &&
+      strstr(buffer, user_failure_str) != NULL)
+    return 1;
+  return is_failure(buffer);
 }
 
 /*
@@ -172,6 +207,136 @@ static int has_shell_prompt(const char *buffer) {
   return (last == '$' || last == '#' || last == '>' || last == '%');
 }
 
+/*
+ * Decide whether a response indicates a successful login.
+ *
+ *   - When the operator supplied an explicit S= success string, an exact
+ *     substring match is required. This is the strongest, lowest-FP mode
+ *     and is the recommended way to drive the module.
+ *   - Otherwise we fall back to has_shell_prompt() which only inspects
+ *     the trailing non-whitespace byte of the response.
+ */
+static int is_success(const char *buffer) {
+  if (buffer == NULL)
+    return 0;
+  if (user_success_str != NULL && *user_success_str != 0)
+    return strstr(buffer, user_success_str) != NULL;
+  return has_shell_prompt(buffer);
+}
+
+/*
+ * Coarse classification of a server response after credentials have been
+ * (partially or fully) submitted. Centralising this logic avoids drift
+ * between the post-username and post-password phases and ensures the
+ * priority order is identical in both:
+ *
+ *     failure phrase  >  login re-prompt  >  password prompt  >  success
+ *
+ * Returning TELNET_RESP_NONE means "no decision yet, keep reading".
+ */
+typedef enum {
+  TELNET_RESP_NONE = 0,
+  TELNET_RESP_SUCCESS,
+  TELNET_RESP_FAILURE,
+  TELNET_RESP_PASSWORD,
+} telnet_resp_t;
+
+static telnet_resp_t classify_response(const char *buffer) {
+  if (buffer == NULL)
+    return TELNET_RESP_NONE;
+  if (is_failure_with_user(buffer))
+    return TELNET_RESP_FAILURE;
+  if (is_login_prompt(buffer))
+    return TELNET_RESP_FAILURE;
+  if (is_password_prompt(buffer))
+    return TELNET_RESP_PASSWORD;
+  if (is_success(buffer))
+    return TELNET_RESP_SUCCESS;
+  return TELNET_RESP_NONE;
+}
+
+/*
+ * Parse the optional module parameter (miscptr) into the operator-supplied
+ * success / failure substrings. Accepted syntaxes:
+ *
+ *     <string>                 legacy: whole value used as success substring
+ *     S=<success>              explicit success substring
+ *     F=<failure>              explicit failure substring
+ *     S=<success>:F=<failure>  both (order is irrelevant)
+ *     F=<failure>:S=<success>  both (order is irrelevant)
+ *
+ * A literal ':' inside a value can be escaped as "\:" exactly as in the
+ * http-form module, so success strings such as "Last login\:" are usable.
+ *
+ * The caller is expected to have already lower-cased miscptr; this routine
+ * only splits and unescapes. The function is idempotent and safe to call
+ * multiple times; previous values are released first.
+ */
+static void telnet_parse_miscptr(char *miscptr) {
+  char *work, *seg_start, *p, *unescaped;
+  int has_prefix;
+
+  if (user_success_str != NULL) {
+    free(user_success_str);
+    user_success_str = NULL;
+  }
+  if (user_failure_str != NULL) {
+    free(user_failure_str);
+    user_failure_str = NULL;
+  }
+
+  if (miscptr == NULL || *miscptr == 0)
+    return;
+
+  has_prefix = (strncmp(miscptr, "s=", 2) == 0 || strncmp(miscptr, "f=", 2) == 0);
+
+  if (!has_prefix) {
+    /* Legacy contract: whole value is a success substring. */
+    user_success_str = strdup(miscptr);
+    return;
+  }
+
+  work = strdup(miscptr);
+  if (work == NULL)
+    return;
+
+  seg_start = work;
+  p = work;
+  while (1) {
+    int at_end = (*p == 0);
+    int at_sep = (*p == ':' && (p == work || *(p - 1) != '\\'));
+    if (at_end || at_sep) {
+      char saved = *p;
+      *p = 0;
+      if (strncmp(seg_start, "s=", 2) == 0) {
+        if (user_success_str != NULL) {
+          free(user_success_str);
+          user_success_str = NULL;
+        }
+        unescaped = hydra_strrep(seg_start + 2, "\\:", ":");
+        user_success_str = strdup(unescaped != NULL ? unescaped : seg_start + 2);
+      } else if (strncmp(seg_start, "f=", 2) == 0) {
+        if (user_failure_str != NULL) {
+          free(user_failure_str);
+          user_failure_str = NULL;
+        }
+        unescaped = hydra_strrep(seg_start + 2, "\\:", ":");
+        user_failure_str = strdup(unescaped != NULL ? unescaped : seg_start + 2);
+      } else if (*seg_start != 0) {
+        hydra_report(stderr,
+                     "[WARNING] telnet: ignoring unknown miscptr segment '%s' "
+                     "(expected S= or F=)\n",
+                     seg_start);
+      }
+      if (saved == 0)
+        break;
+      seg_start = p + 1;
+    }
+    p++;
+  }
+  free(work);
+}
+
 int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE *fp) {
   char *empty = "";
   char *login, *pass, buffer[300];
@@ -231,32 +396,51 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
     }
 
     /*
-     * Wait for the password prompt after sending the username.
+     * Wait for the server's response after sending the username.
      *
-     * This phase, like the banner phase above, must NEVER declare
-     * success. Only two outcomes are valid here:
-     *   - the server asks for a password   -> proceed to send it
-     *   - the server re-prompts for a login -> the username is wrong
+     * Three valid outcomes are recognised here:
+     *   - password prompt   -> proceed to send the candidate password
+     *   - login re-prompt   -> the username is wrong, advance pair
+     *   - explicit failure  -> the username/account is rejected outright
+     *   - success           -> the account has no password and the server
+     *                          dropped us straight into a shell. This is
+     *                          the documented "passwordless account" case
+     *                          (Cisco / embedded devices, Unix users with
+     *                          an empty password field, etc.) and must be
+     *                          reported with the credential pair that
+     *                          triggered it. The legacy module behaved
+     *                          this way; an earlier refactor lost it.
      */
-    int32_t i = 0;
+    int32_t got_password_prompt = 0;
     do {
       if ((buf = hydra_receive_line(s)) == NULL)
         return 1;
 
       (void)make_to_lower(buf);
 
-      if (is_password_prompt(buf))
-        i = 1;
-
-      if (i == 0 && is_login_prompt(buf)) {
+      switch (classify_response(buf)) {
+      case TELNET_RESP_PASSWORD:
+        got_password_prompt = 1;
+        break;
+      case TELNET_RESP_FAILURE:
         free(buf);
         hydra_completed_pair();
         if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
           return 3;
         return 2;
+      case TELNET_RESP_SUCCESS:
+        hydra_report_found_host(port, ip, "telnet", fp);
+        hydra_completed_pair_found();
+        free(buf);
+        if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
+          return 3;
+        return 1;
+      case TELNET_RESP_NONE:
+      default:
+        break;
       }
       free(buf);
-    } while (i == 0);
+    } while (got_password_prompt == 0);
   }
 
   /* Send password */
@@ -279,31 +463,32 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
   /*
    * Response handling after the password has been sent.
    *
-   * Order of checks is significant and must be:
-   *   1) explicit failure message,
-   *   2) password re-prompt,
-   *   3) login re-prompt,
-   *   4) success (operator-supplied string OR a trailing shell prompt).
+   * The four cases below are evaluated in the order imposed by
+   * classify_response():
    *
-   * Putting success last guarantees that a single response containing
-   * both a failure phrase and a stray prompt character (e.g. an error
-   * banner followed by "Login:") is correctly treated as a failure.
+   *     failure phrase  >  login re-prompt  >  password re-prompt  >  success
+   *
+   * Putting success last guarantees that a response containing both a
+   * failure phrase and a stray prompt character (e.g. an error banner
+   * followed by "Login:") is correctly treated as a failure.
+   *
+   * The password-re-prompt branch is the only one that mutates state on
+   * the live socket: the server is still waiting for a password, so we
+   * advance to the next candidate without dropping the connection. Every
+   * other terminal branch returns from start_telnet().
    */
   while ((buf = hydra_receive_line(s)) != NULL) {
     make_to_lower(buf);
 
-    /* 1) Explicit failure phrase wins over everything else. */
-    if (is_failure(buf)) {
+    switch (classify_response(buf)) {
+    case TELNET_RESP_FAILURE:
       free(buf);
       hydra_completed_pair();
       if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
         return 3;
       return 2;
-    }
 
-    /* 2) The server re-asks for a password -> the password was wrong;
-     *    feed the next candidate without dropping the connection. */
-    if (is_password_prompt(buf)) {
+    case TELNET_RESP_PASSWORD:
       hydra_completed_pair();
       free(buf);
       if (strlen(pass = hydra_get_next_password()) == 0)
@@ -323,44 +508,18 @@ int32_t start_telnet(int32_t s, char *ip, int32_t port, unsigned char options, c
         hydra_send(s, buffer, strlen(buffer) + 1, 0);
       }
       continue;
-    }
 
-    /* 3) The server re-asks for a username -> the whole pair is wrong;
-     *    let the outer loop reconnect and try the next pair. */
-    if (is_login_prompt(buf)) {
-      free(buf);
-      hydra_completed_pair();
-      return 2;
-    }
-
-    /* 4) Success detection.
-     *
-     *    - If the operator supplied a success string (-m / miscptr) we
-     *      require an exact substring match. This is the recommended
-     *      reliable mode and the only one that gives strong guarantees
-     *      against false positives.
-     *    - Otherwise we accept the response only when its last
-     *      non-whitespace byte is a recognised shell-prompt character.
-     *      Matching the prompt at the *end* of the line (instead of
-     *      anywhere inside it, as before) eliminates the bulk of the
-     *      structural false positives the previous logic produced.
-     */
-    if (miscptr != NULL) {
-      if (strstr(buf, miscptr) != NULL) {
-        hydra_report_found_host(port, ip, "telnet", fp);
-        hydra_completed_pair_found();
-        free(buf);
-        if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
-          return 3;
-        return 1;
-      }
-    } else if (has_shell_prompt(buf)) {
+    case TELNET_RESP_SUCCESS:
       hydra_report_found_host(port, ip, "telnet", fp);
       hydra_completed_pair_found();
       free(buf);
       if (memcmp(hydra_get_next_pair(), &HYDRA_EXIT, sizeof(HYDRA_EXIT)) == 0)
         return 3;
       return 1;
+
+    case TELNET_RESP_NONE:
+    default:
+      break;
     }
 
     free(buf);
@@ -381,6 +540,7 @@ void service_telnet(char *ip, int32_t sp, unsigned char options, char *miscptr, 
     return;
   if (miscptr != NULL)
     make_to_lower(miscptr);
+  telnet_parse_miscptr(miscptr);
 
   while (1) {
     int32_t first = 0;
@@ -495,19 +655,37 @@ int32_t service_telnet_init(char *ip, int32_t sp, unsigned char options, char *m
 }
 
 void usage_telnet(const char *service) {
-  printf("Module telnet is optionally taking the string which is displayed after\n"
-         "a successful login (case insensitive). Supplying this string is the\n"
-         "single most reliable way to avoid false positives and is strongly\n"
-         "recommended whenever the target's post-login banner is known.\n\n"
-         "Default success detection:\n"
+  printf("Module telnet is optionally taking operator-supplied success and/or\n"
+         "failure substrings. Providing them is the single most reliable way to\n"
+         "avoid false positives and is strongly recommended whenever the\n"
+         "target's post-login banner or rejection message is known.\n\n"
+         "Optional parameter syntax (all matches are case-insensitive):\n"
+         "  <string>                whole value used as a success substring\n"
+         "                          (legacy, kept for backwards compatibility)\n"
+         "  S=<success>             success substring (response must contain it)\n"
+         "  F=<failure>             extra failure substring, in addition to the\n"
+         "                          built-in failure phrase list\n"
+         "  S=<success>:F=<failure> both at once (order is irrelevant)\n"
+         "  \\:                      literal ':' inside a value\n\n"
+         "Default success detection (when no S= is supplied):\n"
          " - Requires an explicit failure phrase to be absent\n"
          " - Requires the response to END with a shell prompt character\n"
          "   ('$', '#', '>' or '%%'); prompt characters appearing inside the\n"
          "   buffer are no longer treated as success on their own\n"
-         " - Never declares success before the password has been sent\n\n"
+         " - Success is never declared before the username has been sent\n"
+         " - A passwordless account that drops straight into a shell after\n"
+         "   the username is correctly reported as a successful login\n\n"
          "Features:\n"
          " - Automatic password-only mode detection (Cisco, embedded devices)\n"
+         " - Passwordless-account detection after username submission\n"
          " - Multilingual prompt support (English, German, Russian, Spanish, ...)\n"
-         " - Specific failure-message patterns to minimise misclassification\n\n"
-         "For password-only servers, use: hydra -l \"\" -P passwords.txt ip telnet\n");
+         " - Specific failure-message patterns to minimise misclassification\n"
+         " - Operator-defined success/failure overrides via S= / F=\n\n"
+         "Examples:\n"
+         "  hydra -l root -P pwd.txt ip telnet\n"
+         "  hydra -l root -P pwd.txt -m 'S=Last login' ip telnet\n"
+         "  hydra -l root -P pwd.txt -m 'F=Authentication failed' ip telnet\n"
+         "  hydra -l root -P pwd.txt -m 'S=$ :F=login incorrect' ip telnet\n\n"
+         "For password-only servers, use: hydra -l \"\" -P passwords.txt ip telnet\n"
+         "For passwordless accounts, combine with -e n to try empty passwords.\n");
 }


### PR DESCRIPTION
Noticed the Telnet module was producing a ton of false positives. The core problem was that the original code treated shell prompt characters (`/`, `>`, `%`, `$`, `#`) anywhere in a server response as proof of a successful login, even before credentials were sent.

The original had two "early success detection" blocks in `start_telnet()`: one in the banner-reading loop, and another right after sending the username (before the password). If a banner like "Welcome to Cisco IOS, press # for help" or "Server v1.0, 100% reliable" came back, hydra called `hydra_report_found_host` immediately. Same thing happened post-username: a reply like "Password (use # to cancel):" got reported as a win.

The original `is_failure()` also matched bare tokens like "wrong", "failed", and "too many" with case-sensitive `strstr`. Those show up all over MOTDs and help text, and the case-sensitive matching meant mixed-case failure messages slipped through entirely.

**What I changed:**

* Stripped out the early success-detection blocks completely. Success is never reported before the password gets sent.
* Wrote `has_shell_prompt()`, which only checks the last non-whitespace byte of the response for `$`, `#`, `>`, `%`. That still catches real shell prompts (bash, csh, Cisco IOS) but ignores paths, percentages, and help text mid-buffer.
* Tightened `is_failure()` to match multi-word phrases only ("bad password", "access denied", "login incorrect", "too many attempts", etc.) and made it always lower-case the input so case doesn't matter.
* Split prompt detection into `is_password_prompt()`, `is_login_prompt()`, and `is_login_prompt_banner()` helpers, with the login prompt detection deliberately stricter post-auth so MOTD text doesn't get mistaken for a re-prompt.

