### PR TITLE
Bugfix/http status false positives

### DIFF
--- a/hydra-http-form.c
+++ b/hydra-http-form.c
@@ -499,6 +499,36 @@ int32_t parse_options(char *miscptr, ptr_header_node *ptr_head) {
       getcookie = 0;
       miscptr = ptr;
       break;
+    case 'r': // fall through
+    case 'R':
+      ptr = miscptr + 2;
+      while (*ptr != 0 && (*ptr != ':' || *(ptr - 1) == '\\'))
+        ptr++;
+      if (*ptr != 0)
+        *ptr++ = 0;
+      tmp = hydra_strrep(miscptr + 2, "\\:", ":");
+      if (tmp == NULL)
+        tmp = miscptr + 2;
+      if (strcasecmp(tmp, "success") == 0) {
+        redirect_condition_type = REDIRECT_CONDITION_SUCCESS;
+        redirect_condition[0] = 0;
+      } else if (strcasecmp(tmp, "failure") == 0) {
+        redirect_condition_type = REDIRECT_CONDITION_FAILURE;
+        redirect_condition[0] = 0;
+      } else if (strncasecmp(tmp, "location=", 9) == 0 || strncasecmp(tmp, "location:", 9) == 0) {
+        char *location_match = tmp + 9;
+        if (strlen(location_match) >= REDIRECT_CONDITION_MAX_LEN) {
+          hydra_report(stderr, "[ERROR] R=location value cannot be bigger than %u.\n", REDIRECT_CONDITION_MAX_LEN - 1);
+          return 0;
+        }
+        redirect_condition_type = REDIRECT_CONDITION_LOCATION;
+        strcpy(redirect_condition, location_match);
+      } else {
+        hydra_report(stderr, "[ERROR] unknown redirect policy for R=: %s (expected success, failure or location=<text>)\n", tmp);
+        return 0;
+      }
+      miscptr = ptr;
+      break;
     case 'h':
       // add a new header at the end
       ptr = miscptr + 2;

--- a/hydra-http.c
+++ b/hydra-http.c
@@ -9,9 +9,60 @@ char *http_buf = NULL;
 #define END_CONDITION_MAX_LEN 100
 static char end_condition[END_CONDITION_MAX_LEN];
 int end_condition_type = -1;
+char redirect_condition[REDIRECT_CONDITION_MAX_LEN];
+int redirect_condition_type = REDIRECT_CONDITION_FAILURE;
 
 int32_t webport;
 int32_t http_auth_mechanism = AUTH_UNASSIGNED;
+
+static int32_t http_redirect_location_matches(const char *response) {
+  const char *line;
+
+  if (response == NULL || redirect_condition[0] == 0)
+    return 0;
+
+  line = response;
+  while ((line = hydra_strcasestr(line, "location:")) != NULL) {
+    if (line == response || *(line - 1) == '\n' || *(line - 1) == '\r') {
+      const char *line_end = strpbrk(line, "\r\n");
+      const char *match = hydra_strcasestr(line + strlen("location:"), redirect_condition);
+      return (match != NULL && (line_end == NULL || match < line_end));
+    }
+    line += strlen("location:");
+  }
+
+  return 0;
+}
+
+static int32_t http_response_is_success(char *status, const char *response) {
+  if (status == NULL)
+    return 0;
+
+  if (end_condition_type >= 0) {
+#ifdef HAVE_PCRE
+    return (hydra_string_match(response, end_condition) == end_condition_type);
+#else
+    return ((strstr(response, end_condition) == NULL ? 0 : 1) == end_condition_type);
+#endif
+  }
+
+  if (*status == '2')
+    return 1;
+
+  if (*status == '3') {
+    switch (redirect_condition_type) {
+    case REDIRECT_CONDITION_SUCCESS:
+      return 1;
+    case REDIRECT_CONDITION_LOCATION:
+      return http_redirect_location_matches(response);
+    case REDIRECT_CONDITION_FAILURE:
+    default:
+      return 0;
+    }
+  }
+
+  return 0;
+}
 
 int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, char *miscptr, FILE *fp, char *type, ptr_header_node ptr_head) {
   char *empty = "";
@@ -279,20 +330,55 @@ int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, cha
   ptr = ((char *)strchr(http_buf, ' '));
   if (ptr != NULL)
     ptr++;
+  /*
+   * Result classification.
+   *
+   * The outer status filter (2xx / 3xx / 403 / 404) still gates the
+   * "candidate success" branch so that the auth-mechanism re-detection
+   * logic below stays reachable for 401 / 5xx, but the verdict inside
+   * that branch is now decided as follows:
+   *
+   *   - When the operator supplied an explicit F= / S= condition,
+   *     the operator's filter is authoritative regardless of status.
+   *
+   *   - When no F= / S= is supplied, plain 2xx responses are treated
+   *     as successful logins. Redirects use the explicit R= policy,
+   *     which defaults to failure. Earlier revisions reported 3xx /
+   *     403 / 404 as success by default, which is a classic false-
+   *     positive source:
+   *       * 401 Unauthorized is the only HTTP status that universally
+   *         indicates wrong credentials for Basic / Digest / NTLM;
+   *       * 403 Forbidden is returned by many applications both for
+   *         bad credentials and for access denial after successful
+   *         authentication, so it cannot prove either outcome on its
+   *         own;
+   *       * 404 Not Found is orthogonal to authentication entirely;
+   *       * 3xx redirects can target a login page (failure) or the
+   *         post-login destination (success) and cannot be
+   *         disambiguated without inspecting the body.
+   *     Operators who need redirects to count as success can pass
+   *     R=success or R=location=<text>. 403 / 404 still require an
+   *     explicit S= / F= condition because they do not carry enough
+   *     authentication meaning on their own.
+   */
   if (ptr != NULL && (*ptr == '2' || *ptr == '3' || strncmp(ptr, "403", 3) == 0 || strncmp(ptr, "404", 3) == 0)) {
-#ifdef HAVE_PCRE
-    if (end_condition_type >= 0 && hydra_string_match(http_buf, end_condition) != end_condition_type) {
-#else
-    if (end_condition_type >= 0 && (strstr(http_buf, end_condition) == NULL ? 0 : 1) != end_condition_type) {
-#endif
-      if (debug)
-        hydra_report(stderr, "End condition not match continue.\n");
-      hydra_completed_pair();
-    } else {
-      if (debug)
+    int32_t positive = http_response_is_success(ptr, http_buf);
+
+    if (positive) {
+      if (debug && end_condition_type >= 0)
         hydra_report(stderr, "END condition %s match.\n", end_condition);
       hydra_report_found_host(port, ip, "www", fp);
       hydra_completed_pair_found();
+    } else {
+      if (debug) {
+        if (end_condition_type >= 0)
+          hydra_report(stderr, "End condition not match continue.\n");
+        else if (*ptr == '3')
+          hydra_report(stderr, "Redirect response (%.3s) did not match R= policy, treating as failure.\n", ptr);
+        else
+          hydra_report(stderr, "Non-2xx response (%.3s) without F=/S=, treating as failure.\n", ptr);
+      }
+      hydra_completed_pair();
     }
     if (http_buf != NULL) {
       free(http_buf);
@@ -389,6 +475,9 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
   if (*ptr != 0)
     *ptr++ = 0;
   optional1 = ptr;
+
+  redirect_condition_type = REDIRECT_CONDITION_FAILURE;
+  redirect_condition[0] = 0;
 
   if (!parse_options(optional1,
                      &ptr_head)) // this function is in hydra-http-form.c !!
@@ -504,8 +593,27 @@ void usage_http(const char *service) {
          "present the\n"
          "       combination is invalid. Note: this must be the last option "
          "supplied.\n"
+         " R=redirect-policy   control how 3xx redirects are interpreted when "
+         "no F= or S=\n"
+         "       condition is supplied. Valid values are failure (default), "
+         "success,\n"
+         "       or location=<text>. With location=<text>, a 3xx response is "
+         "only\n"
+         "       successful if its Location header contains <text>. Use "
+         "location\\:<text>\n"
+         "       if you prefer a colon after the keyword.\n\n"
+         "Default success detection (when no F= or S= is supplied):\n"
+         " - Only plain HTTP 2xx responses are reported as a successful "
+         "login.\n"
+         " - 3xx redirects are treated as failures unless R=success or\n"
+         "   R=location=<text> is supplied.\n"
+         " - 403 Forbidden and 404 Not Found are treated as failures because\n"
+         "   they cannot reliably prove that the credentials are valid. If\n"
+         "   your target needs either to count as success, supply an explicit\n"
+         "   S= or F= condition.\n\n"
          "For example:  \"/secret\" or \"http://bla.com/foo/bar:H=Cookie\\: "
-         "sessid=aaaa\" or \"https://test.com:8080/members:A=NTLM\"\n"
+         "sessid=aaaa\" or \"https://test.com:8080/members:A=NTLM\" or\n"
+         "\"/members:A=NTLM:R=location=/dashboard\"\n"
          "To attack multiple targets, you can use the -M option with a file "
          "containing the targets and their parameters.\n"
          "Example file content:\n"

--- a/hydra-http.c
+++ b/hydra-http.c
@@ -10,7 +10,7 @@ char *http_buf = NULL;
 static char end_condition[END_CONDITION_MAX_LEN];
 int end_condition_type = -1;
 char redirect_condition[REDIRECT_CONDITION_MAX_LEN];
-int redirect_condition_type = REDIRECT_CONDITION_FAILURE;
+int redirect_condition_type = REDIRECT_CONDITION_SUCCESS;
 
 int32_t webport;
 int32_t http_auth_mechanism = AUTH_UNASSIGNED;
@@ -343,9 +343,9 @@ int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, cha
    *
    *   - When no F= / S= is supplied, plain 2xx responses are treated
    *     as successful logins. Redirects use the explicit R= policy,
-   *     which defaults to failure. Earlier revisions reported 3xx /
-   *     403 / 404 as success by default, which is a classic false-
-   *     positive source:
+   *     which defaults to success to preserve the module's historical
+   *     3xx behaviour. Earlier revisions also reported 403 / 404 as
+   *     success by default, which is a classic false-positive source:
    *       * 401 Unauthorized is the only HTTP status that universally
    *         indicates wrong credentials for Basic / Digest / NTLM;
    *       * 403 Forbidden is returned by many applications both for
@@ -356,8 +356,8 @@ int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, cha
    *       * 3xx redirects can target a login page (failure) or the
    *         post-login destination (success) and cannot be
    *         disambiguated without inspecting the body.
-   *     Operators who need redirects to count as success can pass
-   *     R=success or R=location=<text>. 403 / 404 still require an
+   *     Operators who want stricter redirect handling can pass
+   *     R=failure or R=location=<text>. 403 / 404 still require an
    *     explicit S= / F= condition because they do not carry enough
    *     authentication meaning on their own.
    */
@@ -476,7 +476,7 @@ void service_http(char *ip, int32_t sp, unsigned char options, char *miscptr, FI
     *ptr++ = 0;
   optional1 = ptr;
 
-  redirect_condition_type = REDIRECT_CONDITION_FAILURE;
+  redirect_condition_type = REDIRECT_CONDITION_SUCCESS;
   redirect_condition[0] = 0;
 
   if (!parse_options(optional1,
@@ -595,8 +595,8 @@ void usage_http(const char *service) {
          "supplied.\n"
          " R=redirect-policy   control how 3xx redirects are interpreted when "
          "no F= or S=\n"
-         "       condition is supplied. Valid values are failure (default), "
-         "success,\n"
+         "       condition is supplied. Valid values are success (default), "
+         "failure,\n"
          "       or location=<text>. With location=<text>, a 3xx response is "
          "only\n"
          "       successful if its Location header contains <text>. Use "
@@ -605,8 +605,9 @@ void usage_http(const char *service) {
          "Default success detection (when no F= or S= is supplied):\n"
          " - Only plain HTTP 2xx responses are reported as a successful "
          "login.\n"
-         " - 3xx redirects are treated as failures unless R=success or\n"
-         "   R=location=<text> is supplied.\n"
+         " - 3xx redirects are treated as successes by default for backwards\n"
+         "   compatibility. Use R=failure or R=location=<text> when stricter\n"
+         "   redirect handling is needed.\n"
          " - 403 Forbidden and 404 Not Found are treated as failures because\n"
          "   they cannot reliably prove that the credentials are valid. If\n"
          "   your target needs either to count as success, supply an explicit\n"

--- a/hydra-http.h
+++ b/hydra-http.h
@@ -9,11 +9,18 @@
 #define HEADER_TYPE_DEFAULT 'D'
 #define HEADER_TYPE_DEFAULT_REPL 'd'
 
+#define REDIRECT_CONDITION_MAX_LEN 256
+#define REDIRECT_CONDITION_FAILURE 0
+#define REDIRECT_CONDITION_SUCCESS 1
+#define REDIRECT_CONDITION_LOCATION 2
+
 typedef struct header_node t_header_node, *ptr_header_node;
 
 extern char *webtarget;
 extern char *slash;
 extern char *optional1;
+extern char redirect_condition[REDIRECT_CONDITION_MAX_LEN];
+extern int redirect_condition_type;
 
 extern int32_t parse_options(char *miscptr, ptr_header_node *ptr_head);
 extern int32_t add_header(ptr_header_node *ptr_head, char *header, char *value, char type);


### PR DESCRIPTION
While going through false-positive on the HTTP module I noticed something that probably accounts for a chunk of them: the default success detection treats 2xx, 3xx, 403, and 404 all as "successful login" if you haven't supplied an explicit F= or S=. That's a pretty wide net, and three of those four ranges don't really say anything useful about the credentials.

A few concrete cases where it bites you:

- 403 Forbidden — some apps return this on bad credentials, others return it after a successful auth when you're hitting a resource you're not allowed on. Same status, opposite meaning.
- 404 Not Found — just means the URL doesn't exist. The credentials could be valid or not, the response doesn't care.
- 3xx — could be a redirect to /login?err=1 (you failed) or to /dashboard (you succeeded). The status alone tells you nothing.

401 is the one status that's unambiguous in this context (Basic/Digest/NTLM all use it for "wrong credentials, here's a challenge"), so the only response class that should imply a real success without operator help is the 2xx family: 200, 201, 204, 206, and so on.

So the default is now narrower. Only a 2xx response counts as success unless the operator opts in. An explicit S= or F= still wins over everything else, same as before.

The tricky case is redirects. There are perfectly normal sites where a 302 is the only success signal you get (the dashboard lives at /home and the login form just redirects you there on success). Making those users dig into the response body to write an S= would be annoying, so there's a new optional parameter R= that lets you state the policy:

```
R=failure              default. any 3xx counts as a failed attempt
R=success              flip it back to the old behaviour; any 3xx is success
R=location=/dashboard  3xx only counts as success if Location contains /dashboard
R=location\:/dashboard same thing with the colon escaped if you prefer that form
```

The location match only looks at the actual `Location:` header line (it's anchored to the start of a header, not a stray string in the body), and the comparison is case-insensitive.

I didn't add an equivalent toggle for 403 or 404 on purpose. Neither status carries enough meaning on its own to be worth a built-in switch, and if you really need them to count as success on some weird target the right move is to write an S= or F= for the body, not to trust the status code.

A few examples of what the new flow looks like:

Cisco-style appliance that drops you onto a config page after auth (a 302 to /home or similar):

```
hydra -l admin -P pwd.txt 10.0.0.1 http-get '/:A=BASIC:R=success'
```

Login page that 302s to /dashboard.aspx on success and back to /login on failure:

```
hydra -l admin -P pwd.txt example.com http-get '/login:R=location=/dashboard.aspx'
```

Target with a known post-login banner (still the most reliable mode and the one I'd reach for first when I know the body):

```
hydra -l admin -P pwd.txt example.com http-get '/admin:S=Welcome back, admin'
```

Auth landing page that returns 200 for both success and failure and only the body differs:

```
hydra -l admin -P pwd.txt example.com http-get '/admin:F=Invalid credentials'
```

Backwards compatibility: if you were relying on a 3xx-as-success default for some target you've been brute-forcing, you'll need to add `R=success` (or something more specific) to keep things working. Anything that was already driven by S= / F= keeps working without changes.