### PR TITLE
fix: resolve memory leak in proxy connection buffer

### DIFF
--- a/hydra-mod.c
+++ b/hydra-mod.c
@@ -354,7 +354,7 @@ int32_t internal__hydra_connect(char *host, int32_t port, int32_t type, int32_t 
             fprintf(stderr, "[ERROR] CONNECT call to proxy failed with code %c%c%c\n", *tmpptr, *(tmpptr + 1), *(tmpptr + 2));
           err = 1;
         }
-        //        free(buf);
+        free(buf);
       } else {
         if (hydra_strcasestr(proxy_string_type[selected_proxy], "socks5")) {
           //          char buf[1024];


### PR DESCRIPTION
## ????

? `hydra-mod.c` ????????????????????

### ????

? `hydra_connect_proxy()` ???,? HTTP CONNECT ??????? 4096 ??????:

`c
if ((buf = malloc(4096)) == NULL) {
    fprintf(stderr, "[ERROR] could not malloc()\n");
    close(s);
    if (reset_selected)
      selected_proxy = -1;
    return -1;
}
`

?????????(???????),`free(buf)` ???????:

`c
//        free(buf);
`

??????? HTTP CONNECT ???????,???? 4096 ??????????????????,????????????

## ????

???? `free(buf)` ??,?????? HTTP CONNECT ??????????:

`c
// ???
//        free(buf);

// ???
free(buf);
`

## ????

- **??**: `hydra-mod.c`
- **??**: 1 ?????(????)
- **??**: ? - ????????????
- **???**: ??????

## ????

- [x] ????????
- [x] ?????????
- [x] ??????

## ????

?? C ??????????,???? `malloc()` ?????????? `free()` ???