### PR TITLE
Fix file handle leaks in main function

### DIFF
--- a/hydra.c
+++ b/hydra.c
@@ -3625,6 +3625,8 @@ int main(int argc, char *argv[]) {
           bail("Could not allocate enough memory for login file data");
         memset(login_ptr, 0, hydra_brains.sizelogin + hydra_brains.countlogin + 8);
         fill_mem(login_ptr, lfp, 0);
+        fclose(lfp);
+        lfp = NULL;
       } else {
         login_ptr = hydra_options.login;
         hydra_brains.sizelogin = strlen(hydra_options.login) + 1;
@@ -3664,6 +3666,8 @@ int main(int argc, char *argv[]) {
           bail("Could not allocate enough memory for password file data");
         memset(pass_ptr, 0, hydra_brains.sizepass + hydra_brains.countpass + 8);
         fill_mem(pass_ptr, pfp, 0);
+        fclose(pfp);
+        pfp = NULL;
       } else {
         if (hydra_options.pass != NULL) {
           pass_ptr = hydra_options.pass;
@@ -3722,6 +3726,8 @@ int main(int argc, char *argv[]) {
         bail("Could not allocate enough memory for colon file data");
       memset(csv_ptr, 0, hydra_brains.sizelogin + 2 * hydra_brains.countlogin + 8);
       fill_mem(csv_ptr, cfp, 1);
+      fclose(cfp);
+      cfp = NULL;
       // printf("count: %d, size: %d\n", hydra_brains.countlogin,
       // hydra_brains.sizelogin); hydra_dump_data(csv_ptr,
       // hydra_brains.sizelogin
@@ -3786,6 +3792,8 @@ int main(int argc, char *argv[]) {
         bail("Could not allocate enough memory for target file data");
       memset(servers_ptr, 0, sizeinfile + countservers + 8);
       fill_mem(servers_ptr, ifp, 0);
+      fclose(ifp);
+      ifp = NULL;
       sizeservers = sizeinfile;
       tmpptr = servers_ptr;
       for (i = 0; i < countinfile; i++) {


### PR DESCRIPTION
## Problem

Four file handles opened in main() are never closed after reading content into memory, causing resource leaks in long-running brute force sessions:

1. **lfp** (login file) - opened at line 3596, never closed
2. **pfp** (password file) - opened at line 3634, never closed
3. **cfp** (colon file) - opened at line 3692, never closed
4. **ifp** (target file) - opened at line 3756, never closed

## Solution

Add fclose() calls immediately after fill_mem() completes reading each file into memory. The file content is already copied to allocated buffers, so closing the handles is safe.

## Impact

- Prevents file descriptor exhaustion during extended usage
- No functional changes - files are read into memory before closing
- Fixes resource leaks that could cause hangs or crashes in long-running sessions