### PR TITLE
Fix NULL pointer dereference in stringify_headers() error path

### DIFF
--- a/hydra-http.c
+++ b/hydra-http.c
@@ -81,6 +81,8 @@ int32_t start_http(int32_t s, char *ip, int32_t port, unsigned char options, cha
     add_header(&ptr_head, "Content-Length", "0", HEADER_TYPE_DEFAULT);
 
   header = stringify_headers(&ptr_head);
+  if (header == NULL)
+    return 3;
 
   buffer_size = strlen(header) + 500;
   if (!(buffer = malloc(buffer_size))) {


### PR DESCRIPTION
## Motivation

The stringify_headers() function can return NULL when memory allocation fails, but the caller in hydra-http.c does not check for NULL before calling strlen(), causing undefined behavior (segmentation fault).

## Changes

- Added NULL check after stringify_headers() call
- Return error code 3 to maintain consistency with existing error handling
- This prevents undefined behavior when malloc fails inside stringify_headers()

## Testing

- [x] Code compiles without errors
- [x] NULL check prevents segmentation fault on allocation failure
- [x] Error handling is consistent with existing code

## Checklist

- [x] Code follows the project coding standards
- [x] Changes are minimal and focused on the specific issue
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

This is a follow-up fix to PR #1092, addressing another memory safety issue in the same file.